### PR TITLE
add new preference page to choose whether or not checkstyle settings should be used to  write formatter/cleanup config when importing projects

### DIFF
--- a/com.basistech.m2e.code.quality.checkstyle/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.checkstyle/META-INF/MANIFEST.MF
@@ -18,3 +18,10 @@ Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.2.0)",
 Bundle-RequiredExecutionEnvironment: J2SE-1.5,
  JavaSE-1.6
 Bundle-Vendor: Basis Technology Corp.
+Import-Package: org.eclipse.jface.preference,
+ org.eclipse.swt.widgets,
+ org.eclipse.ui,
+ org.eclipse.ui.plugin
+Bundle-Activator: com.basistech.m2e.code.quality.checkstyle.Activator
+Bundle-ActivationPolicy: lazy
+Bundle-Localization: plugin

--- a/com.basistech.m2e.code.quality.checkstyle/build.properties
+++ b/com.basistech.m2e.code.quality.checkstyle/build.properties
@@ -4,5 +4,6 @@ bin.includes = META-INF/,\
                plugin.xml,\
                LICENSE.txt,\
                lifecycle-mapping-metadata.xml,\
-               .
+               .,\
+               plugin.properties
                

--- a/com.basistech.m2e.code.quality.checkstyle/plugin.properties
+++ b/com.basistech.m2e.code.quality.checkstyle/plugin.properties
@@ -1,0 +1,1 @@
+page.checkstyle.name = Checkstyle

--- a/com.basistech.m2e.code.quality.checkstyle/plugin.xml
+++ b/com.basistech.m2e.code.quality.checkstyle/plugin.xml
@@ -12,4 +12,11 @@
    <extension
          point="org.eclipse.m2e.core.lifecycleMappingMetadataSource">
    </extension>
+      <extension point="org.eclipse.ui.preferencePages">
+       <page id="com.basistech.m2e.code.quality.checkstyle.EclipseCheckstylereferencePage"
+	    category="org.eclipse.m2e.core.preferences.Maven2PreferencePage"
+	    class="com.basistech.m2e.code.quality.checkstyle.EclipseCheckstylereferencePage"
+            name="Checkstyle">
+       </page>
+   </extension>
 </plugin>

--- a/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/Activator.java
+++ b/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/Activator.java
@@ -1,0 +1,46 @@
+package com.basistech.m2e.code.quality.checkstyle;
+
+import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.osgi.framework.BundleContext;
+
+
+public class Activator extends AbstractUIPlugin {
+    // The plug-in ID
+    public static final String PLUGIN_ID = "com.basistech.m2e.code.quality.checkstyle"; //$NON-NLS-1$
+
+    // The shared instance
+    private static Activator plugin;
+    
+    /**
+     * The constructor
+     */
+    public Activator() {
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.BundleContext)
+     */
+    public void start(BundleContext context) throws Exception {
+        super.start(context);
+        plugin = this;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
+     */
+    public void stop(BundleContext context) throws Exception {
+        plugin = null;
+        super.stop(context);
+    }
+
+    /**
+     * Returns the shared instance
+     *
+     * @return the shared instance
+     */
+    public static Activator getDefault() {
+        return plugin;
+    }
+}

--- a/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/CheckstyleEclipseConstants.java
+++ b/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/CheckstyleEclipseConstants.java
@@ -27,6 +27,7 @@ public final class CheckstyleEclipseConstants {
     public static final String ECLIPSE_CS_PREFS_FILE = ".checkstyle";
     public static final String ECLIPSE_CS_PREFS_CONFIG_NAME = "maven-checkstyle-plugin";
     public static final String ECLIPSE_CS_CACHE_FILENAME = "${project_loc}/target/checkstyle-cachefile";
+    public static final String ECLIPSE_CS_GENERATE_FORMATTER_SETTINGS = "eclipseCheckstyleGenerateFormatterSettings";
     
     private CheckstyleEclipseConstants() {
         //no instantiation.

--- a/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/EclipseCheckstyleProjectConfigurator.java
+++ b/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/EclipseCheckstyleProjectConfigurator.java
@@ -122,6 +122,7 @@ public class EclipseCheckstyleProjectConfigurator
             new ProjectConfigurationWorkingCopy(ProjectConfigurationFactory
                     .getConfiguration(project));
         pcWorkingCopy.setUseSimpleConfig(false);
+        pcWorkingCopy.setSyncFormatter(Activator.getDefault().getPreferenceStore().getBoolean(CheckstyleEclipseConstants.ECLIPSE_CS_GENERATE_FORMATTER_SETTINGS));
         //build or get the checkconfig
         final ICheckConfiguration checkCfg = 
             this.createOrGetCheckstyleConfig(pcWorkingCopy, ruleset);

--- a/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/EclipseCheckstylereferencePage.java
+++ b/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/EclipseCheckstylereferencePage.java
@@ -1,0 +1,35 @@
+package com.basistech.m2e.code.quality.checkstyle;
+
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+
+public class EclipseCheckstylereferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+
+    private Composite parent;
+
+    public EclipseCheckstylereferencePage() {
+        super(GRID);
+        setPreferenceStore(Activator.getDefault().getPreferenceStore());
+    }
+
+    public void init(IWorkbench workbench) {
+    }
+
+    /*
+     * Creates the field editors. Field editors are abstractions of the common
+     * GUI blocks needed to manipulate various types of preferences. Each field
+     * editor knows how to save and restore itself.
+     */
+    public void createFieldEditors() {
+        parent = getFieldEditorParent();
+        String text;
+
+        text = Messages.EclipseCheckstylereferencePage_0;
+        addField(new BooleanFieldEditor(CheckstyleEclipseConstants.ECLIPSE_CS_GENERATE_FORMATTER_SETTINGS, text, parent));
+
+    }
+
+}

--- a/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/Messages.java
+++ b/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/Messages.java
@@ -1,0 +1,15 @@
+package com.basistech.m2e.code.quality.checkstyle;
+
+import org.eclipse.osgi.util.NLS;
+
+public class Messages extends NLS {
+    private static final String BUNDLE_NAME = "com.basistech.m2e.code.quality.checkstyle.messages"; //$NON-NLS-1$
+    public static String EclipseCheckstylereferencePage_0;
+    static {
+        // initialize resource bundle
+        NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+    }
+
+    private Messages() {
+    }
+}

--- a/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/messages.properties
+++ b/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/messages.properties
@@ -1,0 +1,1 @@
+EclipseCheckstylereferencePage_0=Allow Checkstyle to write formatter/cleanup config when importing projects


### PR DESCRIPTION
Hello,
Currently, the checkstyle m2e connector does not specify any value for the syncFormatter attribute (https://github.com/m2e-code-quality/m2e-code-quality/blob/master/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/EclipseCheckstyleProjectConfigurator.java#L124 )
so its value is false by default.
To set it to true, we could add :

``` java
pcWorkingCopy.setSyncFormatter(true);
```

but the pull request I suggest goes beyond that, allowing the user to decide whether or not (thanks to a new preference page) this value may be set to true when importing projects with a checkstyle configuration in their pom.

This syncformatter attribute, also known as "write formatter/cleanup config (experimental)" (when you right click on a project , checkstyle section) generates JDT formatting rules  based on the checkstyle configuration, when enabled.
Bottom line : when importing his maven project, not only  the user will have Eclipse  enable checkstyle with the right configuration, but also JDT formatter rules matching the checkstyle configuration !
