### PR TITLE
Please apply patch to enable loading of properties containing e.g. a windows path

### DIFF
--- a/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/MavenPluginConfigurationTranslator.java
+++ b/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/MavenPluginConfigurationTranslator.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
  * Copyright 2010 Mohan KR
  * Copyright 2010 Basis Technology Corp.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,6 +35,7 @@ import net.sf.eclipsecs.core.projectconfig.FileSet;
 import net.sf.eclipsecs.core.projectconfig.ProjectConfigurationWorkingCopy;
 import net.sf.eclipsecs.core.util.CheckstylePluginException;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
@@ -63,30 +64,30 @@ public class MavenPluginConfigurationTranslator {
     private final ResourceResolver resourceResolver;
     private final MavenSession session;
     private final MojoExecution execution;
-    
+
     private MavenPluginConfigurationTranslator(
-    		final AbstractMavenPluginProjectConfigurator configurator,
-    		final MavenSession session,
-    		final MavenProject mavenProject,
-    		final MavenPluginWrapper pluginWrapper,
-    		final IProject project) throws CoreException {
-        	this.mavenProject = mavenProject;
-        	this.project = project;
-        	this.basedirUri = this.project.getLocationURI();
-        	this.resourceResolver = ResourceResolver.newInstance(configurator.getPluginClassRealm(session, 
-        			pluginWrapper.getMojoExecution()));
-        	this.session = session;
-        	this.execution = pluginWrapper.getMojoExecution();
-        	this.configurator = configurator;
+            final AbstractMavenPluginProjectConfigurator configurator,
+            final MavenSession session,
+            final MavenProject mavenProject,
+            final MavenPluginWrapper pluginWrapper,
+            final IProject project) throws CoreException {
+            this.mavenProject = mavenProject;
+            this.project = project;
+            this.basedirUri = this.project.getLocationURI();
+            this.resourceResolver = ResourceResolver.newInstance(configurator.getPluginClassRealm(session,
+                    pluginWrapper.getMojoExecution()));
+            this.session = session;
+            this.execution = pluginWrapper.getMojoExecution();
+            this.configurator = configurator;
     }
 
     public boolean isActive() throws CoreException {
         Boolean isSkip = configurator.getParameterValue("skip",
-        		Boolean.class, session, execution);
+                Boolean.class, session, execution);
         return (isSkip != null) ? !isSkip: true;
     }
 
-    public URL getRuleset() 
+    public URL getRuleset()
         throws CheckstylePluginException, CoreException {
         final URL ruleset = this.resourceResolver.resolveLocation(
                 this.getConfigLocation());
@@ -98,11 +99,11 @@ public class MavenPluginConfigurationTranslator {
     }
 
     public String getHeaderFile()
-    	throws CheckstylePluginException, CoreException {
+        throws CheckstylePluginException, CoreException {
         final URL headerResource = this.resourceResolver.resolveLocation(
             getHeaderLocation());
         if (headerResource == null) {
-        	return null;
+            return null;
         }
 
         String outDir = mavenProject.getBuild().getDirectory();
@@ -113,7 +114,7 @@ public class MavenPluginConfigurationTranslator {
     }
 
     public void updateCheckConfigWithIncludeExcludePatterns(
-            final ProjectConfigurationWorkingCopy pcWorkingCopy, final ICheckConfiguration checkCfg) 
+            final ProjectConfigurationWorkingCopy pcWorkingCopy, final ICheckConfiguration checkCfg)
         throws CheckstylePluginException, CoreException {
         final FileSet fs = new FileSet("java-sources", checkCfg);
         fs.setEnabled(true);
@@ -124,55 +125,55 @@ public class MavenPluginConfigurationTranslator {
         pcWorkingCopy.getFileSets().add(fs);
     }
 
-    
+
 
     /**
      * Get the {@literal propertiesLocation} element if present in the configuration.
-     * 
+     *
      * @return the value of the {@code propertyExpansion} element.
-     * @throws CoreException 
+     * @throws CoreException
      */
     protected String getPropertiesLocation() throws CoreException {
-    	return configurator.getParameterValue("propertiesLocation",
-    			String.class, session, execution);
+        return configurator.getParameterValue("propertiesLocation",
+                String.class, session, execution);
     }
 
     /**
      * Get the {@literal propertyExpansion} element if present in the configuration.
-     * 
+     *
      * @return the value of the {@code propertyExpansion} element.
-     * @throws CoreException 
+     * @throws CoreException
      */
     protected String getPropertyExpansion() throws CoreException {
         return configurator.getParameterValue("propertyExpansion",
-        		String.class, session, execution);
+                String.class, session, execution);
     }
 
     /**
      * Get the {@literal includeTestSourceDirectory} element value if present in the configuration.
-     * 
+     *
      * @return the value of the {@code includeTestSourceDirectory} element.
-     * @throws CoreException 
+     * @throws CoreException
      */
     public boolean getIncludeTestSourceDirectory() throws CoreException {
-    	Boolean includeTestSourceDirectory = configurator.getParameterValue("includeTestSourceDirectory",
-    			Boolean.class, session, execution);
-    	if (includeTestSourceDirectory != null) {
-    		return includeTestSourceDirectory.booleanValue();
-    	} else {
-    		return false;
-    	}
+        Boolean includeTestSourceDirectory = configurator.getParameterValue("includeTestSourceDirectory",
+                Boolean.class, session, execution);
+        if (includeTestSourceDirectory != null) {
+            return includeTestSourceDirectory.booleanValue();
+        } else {
+            return false;
+        }
     }
-    
+
     /**
      * Get the {@literal configLocation} element if present in the configuration.
-     * 
+     *
      * @return the value of the {@code configLocation} element.
-     * @throws CoreException 
+     * @throws CoreException
      */
     private String getConfigLocation() throws CoreException {
         String configLocation = configurator.getParameterValue("configLocation",
-        		String.class, session, execution);
+                String.class, session, execution);
         if (configLocation == null) {
             configLocation = CHECKSTYLE_DEFAULT_CONFIG_LOCATION;
         }
@@ -182,7 +183,7 @@ public class MavenPluginConfigurationTranslator {
     private String getHeaderLocation() throws CoreException {
         String configLocation = getConfigLocation();
         String headerLocation = configurator.getParameterValue("headerLocation",
-        		String.class, session, execution);
+                String.class, session, execution);
         if ( "config/maven_checks.xml".equals( configLocation )
           && "LICENSE.txt".equals( headerLocation ) ) {
             headerLocation = "config/maven-header.txt";
@@ -193,32 +194,32 @@ public class MavenPluginConfigurationTranslator {
     private List<String> getIncludes() throws CoreException {
         return this.getPatterns("includes");
     }
-    
+
     private List<String> getExcludes() throws CoreException {
         return this.getPatterns("excludes");
     }
-    
+
     private void copyOut(URL src, File dest) throws CheckstylePluginException {
-    	try {
+        try {
             FileUtils.copyURLToFile(src, dest);
-    	} catch (IOException e) {
-    		throw new CheckstylePluginException(
+        } catch (IOException e) {
+            throw new CheckstylePluginException(
               "Failed to resolve header file from configHeader, SKIPPING Eclipse checkstyle configuration");
-    	}
+        }
     }
 
     /**
-     * 
+     *
      * @return                           A list of {@code FileMatchPattern}'s.
      * @throws CheckstylePluginException if an error occurs getting the include
      *                                   exclude patterns.
-     * @throws CoreException 
+     * @throws CoreException
      */
     private List<FileMatchPattern> getIncludesExcludesFileMatchPatterns()
         throws CheckstylePluginException, CoreException {
 
         final List<FileMatchPattern> patterns = new LinkedList<FileMatchPattern>();
-        
+
         /**
          * Step 1). Get all the source roots (including test sources root, if enabled).
          */
@@ -227,7 +228,7 @@ public class MavenPluginConfigurationTranslator {
         if (getIncludeTestSourceDirectory()) {
             sourceFolders.addAll(this.mavenProject.getTestCompileSourceRoots());
         }
-        
+
         /**
          * Step 2). Get all the includes patterns add them for all source roots.
          * NOTES:
@@ -243,14 +244,14 @@ public class MavenPluginConfigurationTranslator {
                 .getPath();
             if (includePatterns.size() != 0) {
                 patterns.addAll(this.normalizePatternsToCheckstyleFileMatchPattern(
-                				includePatterns, 
-                				folderRelativePath, 
-                				true));
+                                includePatterns,
+                                folderRelativePath,
+                                true));
             } else {
                 patterns.add(new FileMatchPattern(folderRelativePath));
             }
         }
-        
+
         /**
          * Step 3). Get all the excludes patterns add them for all source roots.
          * NOTES:
@@ -259,30 +260,30 @@ public class MavenPluginConfigurationTranslator {
          */
         final List<String> excludePatterns = this.getExcludes();
         for (String folder : sourceFolders) {
-	    String folderRelativePath = 
+        String folderRelativePath =
                this.basedirUri.relativize(new File(folder).toURI()).getPath();
             patterns.addAll(this.normalizePatternsToCheckstyleFileMatchPattern(
-                    excludePatterns, 
-                    this.convertToEclipseCheckstyleRegExpPath(folderRelativePath), 
+                    excludePatterns,
+                    this.convertToEclipseCheckstyleRegExpPath(folderRelativePath),
                     false));
         }
-        
+
         return patterns;
     }
-    
+
     private String convertToEclipseCheckstyleRegExpPath(final String path) {
         String csCompatiblePath = path;
         if (path.endsWith("/")) {
             csCompatiblePath = path.substring(0, path.length() - 1);
-        } 
+        }
         //we append the .* pattern regardless
         csCompatiblePath = csCompatiblePath + ".*";
         return csCompatiblePath;
     }
-    
+
     private List<FileMatchPattern> normalizePatternsToCheckstyleFileMatchPattern(
-            final List<String> patterns, final String relativePath, 
-            final boolean setIsIncludePatternFlag) 
+            final List<String> patterns, final String relativePath,
+            final boolean setIsIncludePatternFlag)
             throws CheckstylePluginException {
         List<FileMatchPattern> fileMatchPatterns = new LinkedList<FileMatchPattern>();
         for (String p: patterns) {
@@ -293,20 +294,20 @@ public class MavenPluginConfigurationTranslator {
         }
         return fileMatchPatterns;
     }
-    
+
     /**
-     * Get the include or exclude patterns from the plugin configuration. 
-     * NOTE: this has to be unfortunately transformed, as Maven Plugin configuration supports 
+     * Get the include or exclude patterns from the plugin configuration.
+     * NOTE: this has to be unfortunately transformed, as Maven Plugin configuration supports
      * ANT style pattern but the Eclipse-CS requires java regex.
-     * 
+     *
      * @param elemName the parent element name (e.g. {@code <includes> or <excludes>}.
      * @return         a {@code List} of include patterns.
-     * @throws CoreException 
+     * @throws CoreException
      */
     private List<String> getPatterns(String elemName) throws CoreException {
         List<String> transformedPatterns = new LinkedList<String>();
-        final String patternsString = configurator.getParameterValue(elemName, String.class, session, 
-        		execution);
+        final String patternsString = configurator.getParameterValue(elemName, String.class, session,
+                execution);
         if (patternsString == null || patternsString.length() == 0) {
             return transformedPatterns;
         }
@@ -327,11 +328,11 @@ public class MavenPluginConfigurationTranslator {
         }
         return transformedPatterns;
     }
-    
+
     /**
      * Helper to convert the maven-checkstyle-plugin includes/excludes pattern
      * to eclipse checkstyle plugin pattern.
-     * 
+     *
      * @param pattern the maven-checkstyle-plugin pattern.
      * @return        the converted checkstyle eclipse pattern.
      */
@@ -364,46 +365,48 @@ public class MavenPluginConfigurationTranslator {
         }
         return sb.toString();
     }
-    
-	public Properties getConfiguredProperties() throws CoreException, CheckstylePluginException {
-		String propertiesLocation = getPropertiesLocation();
-		Properties properties = new Properties();
-		if (propertiesLocation != null) {
-			final URL url = this.resourceResolver.resolveLocation(propertiesLocation);
-			if (url == null) {
-				throw new CheckstylePluginException(String.format(
-						"Failed to resolve propertiesLocation [%s]",
-						propertiesLocation));
-	        }
-			try {
-				properties.load(url.openStream());
-	        } catch (IOException e) {
-	        	throw new CheckstylePluginException(String.format(
-	        			"Failed to LOAD properties from propertiesLocation [%s]",
-	        			propertiesLocation));
-	        }
-		}
-	    return properties;
-	}
-	
-	public void updatePropertiesWithPropertyExpansion(Properties props)
-			throws CheckstylePluginException, CoreException {
-		final String propertyExpansion = this.getPropertyExpansion();
-		if (propertyExpansion != null) {
-			try {
-				props.load(new StringReader(propertyExpansion));
-			} catch (IOException e) {
-				throw new CheckstylePluginException(String.format(
-						"[%s]: Failed to checkstyle propertyExpansion [%s]",
-						CheckstyleEclipseConstants.LOG_PREFIX,
-						propertyExpansion));
-			}
+
+    public Properties getConfiguredProperties() throws CoreException, CheckstylePluginException {
+        String propertiesLocation = getPropertiesLocation();
+        Properties properties = new Properties();
+        if (propertiesLocation != null) {
+            final URL url = this.resourceResolver.resolveLocation(propertiesLocation);
+            if (url == null) {
+                throw new CheckstylePluginException(String.format(
+                        "Failed to resolve propertiesLocation [%s]",
+                        propertiesLocation));
+            }
+            try {
+                properties.load(url.openStream());
+            } catch (IOException e) {
+                throw new CheckstylePluginException(String.format(
+                        "Failed to LOAD properties from propertiesLocation [%s]",
+                        propertiesLocation));
+            }
+        }
+        return properties;
+    }
+
+    public void updatePropertiesWithPropertyExpansion(Properties props)
+            throws CheckstylePluginException, CoreException {
+        final String propertyExpansion = this.getPropertyExpansion();
+        if (propertyExpansion != null) {
+            try {
+                // beware of windows path separator
+                final String escapedPropertyExpansion = StringEscapeUtils.escapeJava(propertyExpansion);
+                props.load(new StringReader(escapedPropertyExpansion));
+            } catch (IOException e) {
+                throw new CheckstylePluginException(String.format(
+                        "[%s]: Failed to checkstyle propertyExpansion [%s]",
+                        CheckstyleEclipseConstants.LOG_PREFIX,
+                        propertyExpansion));
+            }
       }
-	}
-    
+    }
+
     public static MavenPluginConfigurationTranslator newInstance(
-    		AbstractMavenPluginProjectConfigurator configurator,
-    		MavenSession session,
+            AbstractMavenPluginProjectConfigurator configurator,
+            MavenSession session,
             final MavenProject mavenProject,
             final MavenPluginWrapper mavenPlugin,
             final IProject project) throws CoreException {


### PR DESCRIPTION
escape the property expansion string - otherwise loading the properties will fail e.g. if they contain a windows path like C:\temp...

Signed-off-by: Tobias Hammerschmidt tobias.hammerschmidt@gmx.de
