### PR TITLE
#27 source folders consistency with maven-checkstyle-plugin

### DIFF
--- a/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/MavenPluginConfigurationTranslator.java
+++ b/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/MavenPluginConfigurationTranslator.java
@@ -260,10 +260,11 @@ public class MavenPluginConfigurationTranslator {
         /**
          * Step 1). Get all the source roots (including test sources root, if enabled).
          */
-        Set<String> sourceFolders = new HashSet<String>(
-                this.mavenProject.getCompileSourceRoots());
+		Set<String> sourceFolders = new HashSet<String>();
+		sourceFolders.add(this.mavenProject.getBuild().getSourceDirectory());
+
         if (getIncludeTestSourceDirectory()) {
-            sourceFolders.addAll(this.mavenProject.getTestCompileSourceRoots());
+			sourceFolders.add(this.mavenProject.getBuild().getTestSourceDirectory());
         }
 
         /**


### PR DESCRIPTION
Only add project.build.sourceDirectory and project.build.testSourceDirectory to checkstyle source folders. This is consistent with the behaviour of the maven-checkstyle-plugin.
