### PR TITLE
Compatibility with Maven 3.1.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <url>scm:git:git://github.com/m2e-code-quality/m2e-code-quality.git</url>
     </scm>
     <properties>
-        <tycho-version>0.18.0</tycho-version>
+        <tycho-version>0.18.1</tycho-version>
         <orbit.version>R20120526062928</orbit.version>
         <main.basedir>${basedir}</main.basedir>
     </properties>


### PR DESCRIPTION
Launching build with Maven 3.1.x finish with an error with Aether:

```
Exception in thread "main" java.lang.NoSuchMethodError: org.apache.maven.execution.MavenSession.getRepositorySession()Lorg/sonatype/aether/RepositorySystemSession;
        at org.eclipse.tycho.core.maven.utils.PluginRealmHelper.execute(PluginRealmHelper.java:86)
...
```

This error is related to https://cwiki.apache.org/confluence/display/MAVEN/AetherClassNotFound. Solution seems easy: change tycho version from 0.18.0 to 0.18.1. With this change plugin is successfully built in Maven 3.1.x (I have no test other versions of maven).
