### PR TITLE
FindBugs: more correct fix for default enabled detectors & categories.

### DIFF
--- a/com.basistech.m2e.code.quality.findbugs/src/main/java/com/basistech/m2e/code/quality/findbugs/EclipseFindbugsProjectConfigurator.java
+++ b/com.basistech.m2e.code.quality.findbugs/src/main/java/com/basistech/m2e/code/quality/findbugs/EclipseFindbugsProjectConfigurator.java
@@ -32,7 +32,6 @@ import com.basistech.m2e.code.quality.shared.AbstractMavenPluginProjectConfigura
 import com.basistech.m2e.code.quality.shared.MavenPluginWrapper;
 
 import de.tobject.findbugs.FindbugsPlugin;
-import de.tobject.findbugs.preferences.FindBugsPreferenceInitializer;
 import edu.umd.cs.findbugs.config.UserPreferences;
 
 /**
@@ -102,11 +101,10 @@ public class EclipseFindbugsProjectConfigurator extends
 			final MavenSession session, final MojoExecution execution)
 			throws CoreException {
 		log.debug("entering buildFindbugsPreferences");
-		final UserPreferences prefs = FindBugsPreferenceInitializer
+		final UserPreferences prefs = UserPreferences
 				.createDefaultUserPreferences();
 		pluginCfgTranslator.setIncludeFilterFiles(prefs);
 		pluginCfgTranslator.setExcludeFilterFiles(prefs);
-		prefs.getFilterSettings().clearAllCategories();
 		//pluginCfgTranslator.setBugCatagories(prefs);
 		pluginCfgTranslator.setEffort(prefs);
 		pluginCfgTranslator.setMinRank(prefs);

--- a/com.basistech.m2e.code.quality.findbugs/src/main/java/com/basistech/m2e/code/quality/findbugs/MavenPluginConfigurationTranslator.java
+++ b/com.basistech.m2e.code.quality.findbugs/src/main/java/com/basistech/m2e/code/quality/findbugs/MavenPluginConfigurationTranslator.java
@@ -259,7 +259,6 @@ public class MavenPluginConfigurationTranslator {
     public void setVisitors(final UserPreferences prefs) throws CoreException {
         final String visitors = this.configurator.getParameterValue(VISITORS, String.class, session, execution);
         if (visitors == null) {
-            prefs.enableAllDetectors(true);
             return;
         }
         List<String> detectorsList = Arrays.asList(StringUtils.split(visitors, ","));


### PR DESCRIPTION
This commit reverts previous fixes in commits b7515297 & 4dff88f2 and 
make corrections in one line: replace defaut preferences creation from FindBugsPreferenceInitializer  to UserPreferences.

FindBugsPreferenceInitializer performs UserPreferences creation  and 
apply _eclipse_ defaults.
