### PR TITLE
Add support for includeResources and includeTestResources

### DIFF
--- a/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/MavenPluginConfigurationTranslator.java
+++ b/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/MavenPluginConfigurationTranslator.java
@@ -366,6 +366,11 @@ public class MavenPluginConfigurationTranslator {
                     .getResourceIncludes();
             for (Resource resource : this.mavenProject.getBuild()
                     .getTestResources()) {
+            	if (resource.getExcludes().size() > 0
+						|| resource.getIncludes().size() > 0) {
+					// ignore resources that have ex/includes for now
+					continue;
+				}
                 String folderRelativePath = this.basedirUri.relativize(
                         new File(resource.getDirectory()).toURI()).getPath();
                 patterns.addAll(this
@@ -378,6 +383,11 @@ public class MavenPluginConfigurationTranslator {
                     .getResourceExcludes();
             for (Resource resource : this.mavenProject.getBuild()
                     .getTestResources()) {
+            	if (resource.getExcludes().size() > 0
+						|| resource.getIncludes().size() > 0) {
+					// ignore resources that have ex/includes for now
+					continue;
+				}
                 String folderRelativePath = this.basedirUri.relativize(
                         new File(resource.getDirectory()).toURI()).getPath();
                 patterns.addAll(this


### PR DESCRIPTION
With the 2.11 release of the maven checkstyle plugin two new properties were added: [includeResources and includeTestResources](https://maven.apache.org/plugins/maven-checkstyle-plugin/check-mojo.html). This pull request adds support for these new properties.

It won't work for resource folders with include/exclude defined as described in [MCHECKSTYLE-214](http://jira.codehaus.org/browse/MCHECKSTYLE-214).

BTW: Somebody should really run a cleanup of the source code. For a project called m2e-_code-quality_ the indentation, etc. is incredibly inconsistent.
