### PR TITLE
Update m2e to support m2e 1.5

### DIFF
--- a/com.basistech.m2e.code.quality.checkstyle/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.checkstyle/META-INF/MANIFEST.MF
@@ -4,9 +4,9 @@ Bundle-Name: M2Eclipse Project Configurator for Eclipse Checkstyle
 Bundle-SymbolicName: com.basistech.m2e.code.quality.checkstyle
  ;singleton:=true
 Bundle-Version: 1.0.0.qualifier
-Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.5.0)",
- org.eclipse.m2e.core;bundle-version="[1.0.0,1.5.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.5.0)",
+Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.6.0)",
+ org.eclipse.m2e.core;bundle-version="[1.0.0,1.6.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.6.0)",
  org.eclipse.equinox.common;bundle-version="3.6.0",
  org.eclipse.core.resources;bundle-version="3.6.0",
  org.eclipse.ui.console,

--- a/com.basistech.m2e.code.quality.findbugs/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.findbugs/META-INF/MANIFEST.MF
@@ -3,9 +3,9 @@ Bundle-ManifestVersion: 2
 Bundle-Name: M2Eclipse Project Configurator for Eclipse Findbugs
 Bundle-SymbolicName: com.basistech.m2e.code.quality.findbugs;singleton:=true
 Bundle-Version: 1.0.0.qualifier
-Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.5.0)",
- org.eclipse.m2e.core;bundle-version="[1.0.0,1.5.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.5.0)",
+Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.6.0)",
+ org.eclipse.m2e.core;bundle-version="[1.0.0,1.6.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.6.0)",
  org.eclipse.equinox.common;bundle-version="3.6.0",
  org.eclipse.core.resources;bundle-version="3.6.0",
  org.eclipse.ui.console,

--- a/com.basistech.m2e.code.quality.pmd/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.pmd/META-INF/MANIFEST.MF
@@ -4,9 +4,9 @@ Bundle-Name: M2Eclipse Extension to support Eclipse PMD Configuration
 Bundle-SymbolicName: com.basistech.m2e.code.quality.pmd
  ;singleton:=true
 Bundle-Version: 1.0.0.qualifier
-Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.5.0)",
- org.eclipse.m2e.core;bundle-version="[1.0.0,1.5.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.5.0)",
+Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.6.0)",
+ org.eclipse.m2e.core;bundle-version="[1.0.0,1.6.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.6.0)",
  org.eclipse.equinox.common;bundle-version="3.6.0",
  org.eclipse.core.resources;bundle-version="3.6.0",
  org.eclipse.ui.console,

--- a/com.basistech.m2e.code.quality.shared/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.shared/META-INF/MANIFEST.MF
@@ -14,9 +14,9 @@ Export-Package: com.basistech.m2e.code.quality.shared,
  org.apache.http.client.utils
 Bundle-ClassPath: .,
  lib/google-collections-1.0.jar
-Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.5.0)",
- org.eclipse.m2e.core;bundle-version="[1.0.0,1.5.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.5.0)",
+Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.6.0)",
+ org.eclipse.m2e.core;bundle-version="[1.0.0,1.6.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.6.0)",
  org.eclipse.equinox.common;bundle-version="3.4.0",
  org.eclipse.core.resources;bundle-version="3.4.0",
  org.eclipse.ui.console,


### PR DESCRIPTION
update m2e version range to include 1.5.0.
allows to install the update site in an eclipse with m2e 1.5 solves #37
