### PR TITLE
issue-54

### DIFF
--- a/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/MavenPluginConfigurationTranslator.java
+++ b/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/MavenPluginConfigurationTranslator.java
@@ -112,7 +112,7 @@ public class MavenPluginConfigurationTranslator {
             return null;
         }
 
-        String outDir = mavenProject.getBuild().getDirectory();
+        File outDir = project.getWorkingLocation(configurator.getId()).toFile();
         File headerFile = new File(outDir, "checkstyle-header-" + getExecutionId() + ".txt");
         copyOut(headerResource, headerFile);
 
@@ -131,7 +131,7 @@ public class MavenPluginConfigurationTranslator {
             return null;
         }
 
-        String outDir = mavenProject.getBuild().getDirectory();
+        File outDir = project.getWorkingLocation(configurator.getId()).toFile();
         File suppressionsFile = new File(outDir, "checkstyle-suppressions-" + getExecutionId() + ".xml");
         copyOut(suppressionsResource, suppressionsFile);
 


### PR DESCRIPTION
Writes the `checkstyle-header.txt` and `checkstyle-suppressions.xml` to the plugin project metadata location (= `.metadata/.plugins/org.eclipse.core.resources/.projects/<projectName>/com.basistech.m2e.code.quality.checkstyleConfigurator/`) instead of the maven `/target` directory, in order to avoid conflicts between maven build and eclipse build.

Fixes #54