### PR TITLE
m2e-code-quality/m2e-code-quality#58: Support for Checkstyle 6.x

### DIFF
--- a/com.basistech.m2e.code.quality.checkstyle.feature/feature.xml
+++ b/com.basistech.m2e.code.quality.checkstyle.feature/feature.xml
@@ -201,9 +201,9 @@ Copyright (c) 2010 Basis Technology Corp.
    <requires>
       <import plugin="org.eclipse.core.runtime" version="3.6.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.core.resources" version="3.6.0" match="greaterOrEqual"/>
-      <import plugin="net.sf.eclipsecs.core" version="5.2.0" match="compatible"/>
-      <import plugin="net.sf.eclipsecs.checkstyle" version="5.2.0" match="compatible"/>
-      <import feature="net.sf.eclipsecs" version="5.2.0" match="compatible"/>
+      <import plugin="net.sf.eclipsecs.core" version="5.2.0" match="greaterOrEqual"/>
+      <import plugin="net.sf.eclipsecs.checkstyle" version="5.2.0" match="greaterOrEqual"/>
+      <import feature="net.sf.eclipsecs" version="5.2.0" match="greaterOrEqual"/>
    </requires>
 
    <plugin

--- a/com.basistech.m2e.code.quality.checkstyle/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.checkstyle/META-INF/MANIFEST.MF
@@ -12,8 +12,8 @@ Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.6.0)",
  org.eclipse.ui.console,
  org.eclipse.jdt.core;bundle-version="3.6.0",
  org.eclipse.core.runtime;bundle-version="3.6.0",
- net.sf.eclipsecs.core;bundle-version="[5.2.0,6.0.0)",
- net.sf.eclipsecs.checkstyle;bundle-version="[5.2.0,6.0.0)",
+ net.sf.eclipsecs.core;bundle-version="5.2.0",
+ net.sf.eclipsecs.checkstyle;bundle-version="5.2.0",
  com.basistech.m2e.code.quality.shared;bundle-version="0.13.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Vendor: Basis Technology Corp.

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <repository>
             <id>cs</id>
             <layout>p2</layout>
-            <url>http://m2e-code-quality.github.com/m2e-code-quality/checkstyle-p2-repository</url>
+            <url>http://eclipse-cs.sf.net/update</url>
         </repository>
         <repository>
             <id>pmd</id>


### PR DESCRIPTION
- Match checkstyle eclipse plugin greaterOrEquals rather than
  compatible.
- Use (official?) Checkstyle repo http://eclipse-cs.sf.net/update
