### PR TITLE
Eclipse Luna minimum required JDK is 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
 
     <modules>


### PR DESCRIPTION
So this plugin might set its source and target version to 1.7 as well now it's compiling against luna.