### PR TITLE
Add import for org.apache.commons.lang to use StringEscapeUtils

### DIFF
--- a/com.basistech.m2e.code.quality.checkstyle/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.checkstyle/META-INF/MANIFEST.MF
@@ -14,10 +14,12 @@ Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.7.0)",
  org.eclipse.core.runtime;bundle-version="3.6.0",
  net.sf.eclipsecs.core;bundle-version="5.2.0",
  net.sf.eclipsecs.checkstyle;bundle-version="5.2.0",
- com.basistech.m2e.code.quality.shared;bundle-version="0.13.0"
+ com.basistech.m2e.code.quality.shared;bundle-version="0.13.0",
+ org.apache.commons.lang;bundle-version="2.6.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Basis Technology Corp.
-Import-Package: org.eclipse.jface.preference,
+Import-Package: org.apache.commons.lang,
+ org.eclipse.jface.preference,
  org.eclipse.swt.widgets,
  org.eclipse.ui,
  org.eclipse.ui.plugin


### PR DESCRIPTION
The current develop branch doesn't build -> https://travis-ci.org/m2e-code-quality/m2e-code-quality/builds/81722940

This PR should fix it...