### PR TITLE
initial checkin of m2e cs example

### DIFF
--- a/test-projects/failing-checkstyle-example/build-tools/pom.xml
+++ b/test-projects/failing-checkstyle-example/build-tools/pom.xml
@@ -1,0 +1,14 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+
+  <groupId>de.spiller.test</groupId>
+  <artifactId>build-tools</artifactId>
+  <packaging>jar</packaging>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <name>Java Code Quality Resources</name>
+  <description>This project contains codestyle guidelines used by Maven and Eclipse</description>
+
+</project>

--- a/test-projects/failing-checkstyle-example/build-tools/src/main/resources/PMDRules.xml
+++ b/test-projects/failing-checkstyle-example/build-tools/src/main/resources/PMDRules.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset name="PMD example Ruleset"
+ xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+	<description>Custom PMD Ruleset</description>
+
+	<!-- complete rulesets -->
+	<rule ref="rulesets/java/basic.xml">
+		<exclude name="OverrideBothEqualsAndHashcode" /><!-- Checkstyle -->
+		<exclude name="DoubleCheckedLocking" /><!-- Checkstyle -->
+		<exclude name="UnnecessaryFinalModifier" /><!-- Checkstyle -->
+	</rule>
+		
+</ruleset>

--- a/test-projects/failing-checkstyle-example/build-tools/src/main/resources/checkstyle-suppressions.xml
+++ b/test-projects/failing-checkstyle-example/build-tools/src/main/resources/checkstyle-suppressions.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+
+    <suppress checks=".*"
+              files="[/\\]generated[/\\]"/>
+    <suppress checks=".*"
+              files="[/\\]generated-sources[/\\]"/>
+    <suppress checks="JavadocPackage" files="[\\/]src[\\/]test[\\/]" />
+    <suppress checks="JavadocMethod" files="[\\/]src[\\/]test[\\/]" />
+    <suppress checks="JavadocType" files="[\\/]src[\\/]test[\\/]" />
+    <suppress checks="JavadocVariable" files="[\\/]src[\\/]test[\\/]" />
+    
+</suppressions>

--- a/test-projects/failing-checkstyle-example/build-tools/src/main/resources/checkstyle.properties
+++ b/test-projects/failing-checkstyle-example/build-tools/src/main/resources/checkstyle.properties
@@ -1,0 +1,1 @@
+config_loc=

--- a/test-projects/failing-checkstyle-example/build-tools/src/main/resources/checkstyle.xml
+++ b/test-projects/failing-checkstyle-example/build-tools/src/main/resources/checkstyle.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+
+
+
+<module name="Checker">
+
+  <property name="severity" value="${checkstyle.severity}"
+    default="error" />
+
+
+  <module name="FileLength" />
+  <module name="FileTabCharacter" />
+  <module name="RegexpMultiline">
+    <property name="severity" value="warning" />
+    <property name="format"
+      value="(System\.(out)|(err)\.print)|(\.printStackTrace)" />
+    <property name="message"
+      value="Use a logger instead of System.out.println()" />
+  </module>
+  <!-- <module name="RegexpSingleline"> -->
+  <!-- <property name="severity" value="info" /> -->
+  <!-- <property name="format" value="\s+$" /> -->
+  <!-- <property name="message" value="Line has trailing spaces." /> -->
+  <!-- </module> -->
+
+  <!-- enables filtering of checks with CHECKSTYLE:OFF ... CHECKSTYLE:ON -->
+  <module name="SuppressionCommentFilter" />
+  <module name="SuppressionFilter">
+    <property name="file" value="${config_loc}/checkstyle-suppressions.xml" />
+  </module>
+</module><!-- end of checker -->

--- a/test-projects/failing-checkstyle-example/failing-checkstyle-example-core/pom.xml
+++ b/test-projects/failing-checkstyle-example/failing-checkstyle-example-core/pom.xml
@@ -1,0 +1,10 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>de.spiller.test</groupId>
+    <artifactId>failing-checkstyle-example-parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>failing-checkstyle-example-core</artifactId>
+</project>

--- a/test-projects/failing-checkstyle-example/failing-checkstyle-example-persistence/pom.xml
+++ b/test-projects/failing-checkstyle-example/failing-checkstyle-example-persistence/pom.xml
@@ -1,0 +1,10 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>de.spiller.test</groupId>
+    <artifactId>failing-checkstyle-example-parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>failing-checkstyle-example-persistence</artifactId>
+</project>

--- a/test-projects/failing-checkstyle-example/pom.xml
+++ b/test-projects/failing-checkstyle-example/pom.xml
@@ -1,0 +1,129 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>de.spiller.test</groupId>
+  <artifactId>failing-checkstyle-example-parent</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>m2e quality example parent</name>
+  <description>Parent for a m2e quality check example</description>
+  <modules>
+    <module>build-tools</module>
+    <module>failing-checkstyle-example-persistence</module>
+    <module>failing-checkstyle-example-core</module>
+  </modules>
+
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <compileSource>1.8</compileSource>
+    <checkstyle.failsOnError>true</checkstyle.failsOnError>
+    <pmd.failurePriority>2</pmd.failurePriority>
+
+    <maven.compiler.target>${compileSource}</maven.compiler.target>
+    <maven.compiler.source>${compileSource}</maven.compiler.source>
+
+    <build.tools.version>${project.version}</build.tools.version>
+    <maven.assembly.version>2.6</maven.assembly.version>
+    <maven.checkstyle.version>2.17</maven.checkstyle.version>
+    <maven.pmd.version>3.6</maven.pmd.version>
+  </properties>
+
+
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <version>${maven.checkstyle.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-pmd-plugin</artifactId>
+          <version>${maven.pmd.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>${maven.assembly.version}</version>
+          <configuration>
+            <descriptorRefs>
+              <descriptorRef>src</descriptorRef>
+            </descriptorRefs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>build-tools</artifactId>
+            <version>${build.tools.version}</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <consoleOutput>false</consoleOutput>
+          <propertyExpansion>basedir=${basedir}</propertyExpansion>
+          <propertiesLocation>checkstyle.properties</propertiesLocation>
+          <configLocation>checkstyle.xml</configLocation>
+          <excludes>target/generated-sources/*</excludes>
+          <suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>checkstyle</goal>
+            </goals>
+            <configuration>
+              <failsOnError>${checkstyle.failsOnError}</failsOnError>
+              <consoleOutput>false</consoleOutput>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>build-tools</artifactId>
+            <version>${build.tools.version}</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <targetJdk>${compileSource}</targetJdk>
+          <rulesets>
+            <ruleset>PMDRules.xml</ruleset>
+          </rulesets>
+          <failurePriority>${pmd.failurePriority}</failurePriority>
+          <verbose>false</verbose>
+          <printFailingErrors>true</printFailingErrors>
+          <excludeRoots>
+            <excludeRoot>target/generated-sources</excludeRoot>
+          </excludeRoots>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>compile</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
Hi there,

I've added a Maven multi module project with a build-tools module with short configurations for PMD and Checkstyle in test-projects/failing-checkstyle-example.

When I import the project with "import existing maven projects" in Eclipse Mars the pmd configuration is generated, but not the checkstyle configuration.

regards,
Martin