### PR TITLE
Support for Eclipse Neon 1a

### DIFF
--- a/com.basistech.m2e.code.quality.checkstyle/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.checkstyle/META-INF/MANIFEST.MF
@@ -4,9 +4,9 @@ Bundle-Name: M2Eclipse Project Configurator for Eclipse Checkstyle
 Bundle-SymbolicName: com.basistech.m2e.code.quality.checkstyle
  ;singleton:=true
 Bundle-Version: 1.0.0.qualifier
-Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.8.0)",
- org.eclipse.m2e.core;bundle-version="[1.0.0,1.8.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.8.0)",
+Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.9.0)",
+ org.eclipse.m2e.core;bundle-version="[1.0.0,1.9.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.9.0)",
  org.eclipse.equinox.common;bundle-version="3.6.0",
  org.eclipse.core.resources;bundle-version="3.6.0",
  org.eclipse.ui.console,

--- a/com.basistech.m2e.code.quality.findbugs/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.findbugs/META-INF/MANIFEST.MF
@@ -3,9 +3,9 @@ Bundle-ManifestVersion: 2
 Bundle-Name: M2Eclipse Project Configurator for Eclipse Findbugs
 Bundle-SymbolicName: com.basistech.m2e.code.quality.findbugs;singleton:=true
 Bundle-Version: 1.0.0.qualifier
-Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.8.0)",
- org.eclipse.m2e.core;bundle-version="[1.0.0,1.8.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.8.0)",
+Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.9.0)",
+ org.eclipse.m2e.core;bundle-version="[1.0.0,1.9.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.9.0)",
  org.eclipse.equinox.common;bundle-version="3.6.0",
  org.eclipse.core.resources;bundle-version="3.6.0",
  org.eclipse.ui.console,

--- a/com.basistech.m2e.code.quality.pmd/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.pmd/META-INF/MANIFEST.MF
@@ -4,9 +4,9 @@ Bundle-Name: M2Eclipse Extension to support Eclipse PMD Configuration
 Bundle-SymbolicName: com.basistech.m2e.code.quality.pmd
  ;singleton:=true
 Bundle-Version: 1.0.0.qualifier
-Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.8.0)",
- org.eclipse.m2e.core;bundle-version="[1.0.0,1.8.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.8.0)",
+Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.9.0)",
+ org.eclipse.m2e.core;bundle-version="[1.0.0,1.9.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.9.0)",
  org.eclipse.equinox.common;bundle-version="3.6.0",
  org.eclipse.core.resources;bundle-version="3.6.0",
  org.eclipse.ui.console,

--- a/com.basistech.m2e.code.quality.shared/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.shared/META-INF/MANIFEST.MF
@@ -12,9 +12,9 @@ Export-Package: com.basistech.m2e.code.quality.shared,
  com.google.common.collect
 Bundle-ClassPath: .,
  lib/google-collections-1.0.jar
-Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.8.0)",
- org.eclipse.m2e.core;bundle-version="[1.0.0,1.8.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.8.0)",
+Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.9.0)",
+ org.eclipse.m2e.core;bundle-version="[1.0.0,1.9.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.9.0)",
  org.eclipse.equinox.common;bundle-version="3.4.0",
  org.eclipse.core.resources;bundle-version="3.4.0",
  org.eclipse.ui.console,

--- a/neon/neon.target
+++ b/neon/neon.target
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?><target name="Eclipse 4.6.x (Neon)" sequenceNumber="66">
+<locations>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.jdt.feature.group" version="3.12.1.v20160907-1200"/>
+<repository location="http://download.eclipse.org/releases/neon/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="net.sf.eclipsecs.feature.group" version="6.19.1.201607051943"/>
+<repository location="http://sourceforge.net/projects/eclipse-cs/files/updatesite/6.19.1"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="2.0.0.20111221"/>
+<repository location="http://m2e-code-quality.github.io/m2e-code-quality/findbugs-p2-repository"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.8.0.20160921-2002"/>
+<unit id="org.eclipse.m2e.feature.feature.group" version="1.8.0.20160921-2002"/>
+<repository location="http://download.eclipse.org/technology/m2e/milestones/1.8"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="net.sourceforge.pmd.eclipse.feature.group" version="4.0.10.v20160626-1043"/>
+<repository location="http://sourceforge.net/projects/pmd/files/pmd-eclipse/update-site/"/>
+</location>
+</locations>
+<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+</target>

--- a/neon/pom.xml
+++ b/neon/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.basistech.m2e-code-quality</groupId>
+        <artifactId>m2e-code-quality-plugins</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>neon</artifactId>
+    <packaging>eclipse-target-definition</packaging>
+    <name>Neon Target Definition</name>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -17,16 +17,16 @@
     </scm>
 
     <properties>
-        <target.platform>mars</target.platform>
+        <target.platform>neon</target.platform>
 
-        <tycho-version>0.24.0</tycho-version>
-        <orbit.version>R20160221192158</orbit.version>
+        <tycho-version>0.26.0</tycho-version>
+        <orbit.version>S20161021172207</orbit.version>
         <main.basedir>${basedir}</main.basedir>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <modules>
@@ -40,6 +40,7 @@
         <module>com.basistech.m2e.code.quality.pmd</module>
         <module>com.basistech.m2e.code.quality.pmd.feature</module>
         <module>com.basistech.m2e.code.quality.site</module>
+        <module>neon</module>
         <module>mars</module>
         <module>luna</module>
     </modules>


### PR DESCRIPTION
The project m2e has updated the plugin to 1.8.0 version that it's compatible with Eclipse Neon 1a. Updated neon IDEs shall no work with m2e-code-quality. These changes seems to work to recover compatibility.
