### PR TITLE
Use new pmd-eclipse-plugin update site

### DIFF
--- a/com.basistech.m2e.code.quality.site/associate-sites.xml
+++ b/com.basistech.m2e.code.quality.site/associate-sites.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <associateSites>
   <associateSite url="http://eclipse-cs.sourceforge.net/update" label="eclipse checkstyle" />
-  <associateSite url="http://sourceforge.net/projects/pmd/files/pmd-eclipse/update-site" label="eclipse pmd" />
+  <associateSite url="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/" label="eclipse pmd" />
   <associateSite url="http://findbugs.cs.umd.edu/eclipse" label="eclipse findbugs" />
 </associateSites>

--- a/m2e-code-quality.setup
+++ b/m2e-code-quality.setup
@@ -86,7 +86,7 @@
           rootFolder="${git.clone.location}"
           locateNestedProjects="true"/>
       <repositoryList
-          name="Oygen">
+          name="Oxygen">
         <repository
             url="http://download.eclipse.org/releases/oxygen"/>
         <repository
@@ -94,7 +94,7 @@
         <repository
             url="http://eclipse-cs.sf.net/update"/>
         <repository
-            url="https://sourceforge.net/projects/pmd/files/pmd-eclipse/update-site/"/>
+            url="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
         <repository
             url="http://download.eclipse.org/technology/m2e/milestones/1.8"/>
       </repositoryList>
@@ -107,7 +107,7 @@
         <repository
             url="http://eclipse-cs.sf.net/update"/>
         <repository
-            url="https://sourceforge.net/projects/pmd/files/pmd-eclipse/update-site/"/>
+            url="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
         <repository
             url="http://download.eclipse.org/technology/m2e/milestones/1.7"/>
       </repositoryList>
@@ -120,7 +120,7 @@
         <repository
             url="http://eclipse-cs.sf.net/update"/>
         <repository
-            url="https://sourceforge.net/projects/pmd/files/pmd-eclipse/update-site/"/>
+            url="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
         <repository
             url="http://download.eclipse.org/technology/m2e/milestones/1.6"/>
       </repositoryList>

--- a/mars/mars.target
+++ b/mars/mars.target
@@ -12,7 +12,7 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="net.sourceforge.pmd.eclipse.feature.group" version="4.0.8.v20151204-2156"/>
-<repository location="http://sourceforge.net/projects/pmd/files/pmd-eclipse/update-site/"/>
+<repository location="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="2.0.0.20111221"/>

--- a/neon/neon.target
+++ b/neon/neon.target
@@ -12,7 +12,7 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="net.sourceforge.pmd.eclipse.feature.group" version="4.0.13.v20170429-1921"/>
-<repository location="https://sourceforge.net/projects/pmd/files/pmd-eclipse/update-site/"/>
+<repository location="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="3.0.1.20150306-5afe4d1"/>

--- a/oxygen/oxygen.target
+++ b/oxygen/oxygen.target
@@ -12,7 +12,7 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="net.sourceforge.pmd.eclipse.feature.group" version="4.0.13.v20170429-1921"/>
-<repository location="https://sourceforge.net/projects/pmd/files/pmd-eclipse/update-site/"/>
+<repository location="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="3.0.1.20150306-5afe4d1"/>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <repository>
             <id>pmd</id>
             <layout>p2</layout>
-            <url>https://sourceforge.net/projects/pmd/files/pmd-eclipse/update-site/</url>
+            <url>https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/</url>
         </repository>
         <repository>
             <id>findbugs</id>


### PR DESCRIPTION
This uses the new update site of pmd-eclipse-plugin: https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/

Without this change, I cannot build m2e-code-quality anymore... seems like the sourceforge mirrors return invalid SSL certs regarding the hostnames...