### PR TITLE
Remove executionId prefixes added by tiles-maven-plugin

### DIFF
--- a/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/MavenPluginConfigurationTranslator.java
+++ b/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/MavenPluginConfigurationTranslator.java
@@ -211,7 +211,12 @@ public class MavenPluginConfigurationTranslator
 	}
 
 	public String getExecutionId() {
-		return execution.getExecutionId();
+		String result = execution.getExecutionId();
+		int tilesSeparatorIndex = result.indexOf("::");
+		if (tilesSeparatorIndex != -1) {
+			result = result.substring(tilesSeparatorIndex + 2);
+		}
+		return result;
 	}
 
 	/**


### PR DESCRIPTION
The [tiles-maven-plugin](https://github.com/repaint-io/maven-tiles) adds executions that are prefixed with the tile name (for better debugging output). When you use a tile to include e.g. checkstyle, this prefix needs to be removed to work