### PR TITLE
Added - Eclipse Photon Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
     - env: TARGETPLATFORM=mars
     - env: TARGETPLATFORM=neon
     - env: TARGETPLATFORM=oxygen
+    - env: TARGETPLATFORM=photon
   fast_finish: true
 script:
   - mvn --batch-mode -Dtarget.platform=$TARGETPLATFORM clean test

--- a/com.basistech.m2e.code.quality.checkstyle/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.checkstyle/META-INF/MANIFEST.MF
@@ -4,9 +4,9 @@ Bundle-Name: M2Eclipse Project Configurator for Eclipse Checkstyle
 Bundle-SymbolicName: com.basistech.m2e.code.quality.checkstyle
  ;singleton:=true
 Bundle-Version: 1.0.0.qualifier
-Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.9.0)",
- org.eclipse.m2e.core;bundle-version="[1.0.0,1.9.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.9.0)",
+Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.10.0)",
+ org.eclipse.m2e.core;bundle-version="[1.0.0,1.10.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.10.0)",
  org.eclipse.equinox.common;bundle-version="3.6.0",
  org.eclipse.core.resources;bundle-version="3.6.0",
  org.eclipse.ui.console,

--- a/com.basistech.m2e.code.quality.findbugs/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.findbugs/META-INF/MANIFEST.MF
@@ -3,9 +3,9 @@ Bundle-ManifestVersion: 2
 Bundle-Name: M2Eclipse Project Configurator for Eclipse Findbugs
 Bundle-SymbolicName: com.basistech.m2e.code.quality.findbugs;singleton:=true
 Bundle-Version: 1.0.0.qualifier
-Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.9.0)",
- org.eclipse.m2e.core;bundle-version="[1.0.0,1.9.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.9.0)",
+Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.10.0)",
+ org.eclipse.m2e.core;bundle-version="[1.0.0,1.10.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.10.0)",
  org.eclipse.equinox.common;bundle-version="3.6.0",
  org.eclipse.core.resources;bundle-version="3.6.0",
  org.eclipse.ui.console,

--- a/com.basistech.m2e.code.quality.pmd/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.pmd/META-INF/MANIFEST.MF
@@ -4,9 +4,9 @@ Bundle-Name: M2Eclipse Extension to support Eclipse PMD Configuration
 Bundle-SymbolicName: com.basistech.m2e.code.quality.pmd
  ;singleton:=true
 Bundle-Version: 1.0.0.qualifier
-Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.9.0)",
- org.eclipse.m2e.core;bundle-version="[1.0.0,1.9.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.9.0)",
+Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.10.0)",
+ org.eclipse.m2e.core;bundle-version="[1.0.0,1.10.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.10.0)",
  org.eclipse.equinox.common;bundle-version="3.6.0",
  org.eclipse.core.resources;bundle-version="3.6.0",
  org.eclipse.ui.console,

--- a/com.basistech.m2e.code.quality.pmd/src/main/java/com/basistech/m2e/code/quality/pmd/EclipsePmdProjectConfigurator.java
+++ b/com.basistech.m2e.code.quality.pmd/src/main/java/com/basistech/m2e/code/quality/pmd/EclipsePmdProjectConfigurator.java
@@ -1,13 +1,14 @@
+//@formatter:off
 /*******************************************************************************
  * Copyright 2010 Mohan KR
  * Copyright 2010 Basis Technology Corp.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -66,6 +67,7 @@ import net.sourceforge.pmd.eclipse.runtime.properties.IProjectProperties;
 import net.sourceforge.pmd.eclipse.runtime.properties.IProjectPropertiesManager;
 import net.sourceforge.pmd.eclipse.runtime.properties.PropertiesException;
 import net.sourceforge.pmd.eclipse.runtime.writer.WriterException;
+import net.sourceforge.pmd.util.ResourceLoader;
 
 public class EclipsePmdProjectConfigurator
         extends AbstractMavenPluginProjectConfigurator {
@@ -176,7 +178,7 @@ public class EclipsePmdProjectConfigurator
 
 	/**
 	 * Configures the PMD plugin based on the POM contents
-	 * 
+	 *
 	 * @throws CoreException
 	 *             if the creation failed.
 	 */
@@ -249,18 +251,20 @@ public class EclipsePmdProjectConfigurator
 				final RuleSetReferenceId resolvedRuleSetReference =
 				        new RuleSetReferenceId(loc) {
 
-					        @Override
-					        public InputStream getInputStream(
-				                    final ClassLoader arg0)
-				                    throws RuleSetNotFoundException {
-						        try {
-							        return resolvedLocation.openStream();
-						        } catch (final IOException e) {
-							        // ignore them.
-						        }
-						        LOG.warn("No ruleset found for {}", loc);
-						        return null;
-					        }
+				            // PMD seems to have changed the method signature
+				            // public InputStream getInputStream(final ClassLoader arg0)
+                            @Override
+                            public InputStream getInputStream(
+                                    final ResourceLoader resourceLoader)
+                                    throws RuleSetNotFoundException {
+                                try {
+                                    return resolvedLocation.openStream();
+                                } catch (final IOException e) {
+                                    // ignore them.
+                                }
+                                LOG.warn("No ruleset found for {}", loc);
+                                return null;
+                            }
 				        };
 				ruleSetAtLocations =
 				        this.factory.createRuleSet(resolvedRuleSetReference);
@@ -275,7 +279,7 @@ public class EclipsePmdProjectConfigurator
 
 	/**
 	 * Serializes the ruleset for configuring eclipse PMD plugin.
-	 * 
+	 *
 	 * @param rulesetFile
 	 *            the ruleset File resource.
 	 * @param ruleSet

--- a/com.basistech.m2e.code.quality.shared/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.shared/META-INF/MANIFEST.MF
@@ -12,9 +12,9 @@ Export-Package: com.basistech.m2e.code.quality.shared,
  com.google.common.collect
 Bundle-ClassPath: .,
  lib/google-collections-1.0.jar
-Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.9.0)",
- org.eclipse.m2e.core;bundle-version="[1.0.0,1.9.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.9.0)",
+Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,1.10.0)",
+ org.eclipse.m2e.core;bundle-version="[1.0.0,1.10.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.10.0)",
  org.eclipse.equinox.common;bundle-version="3.4.0",
  org.eclipse.core.resources;bundle-version="3.4.0",
  org.eclipse.ui.console,

--- a/m2e-code-quality.setup
+++ b/m2e-code-quality.setup
@@ -140,7 +140,8 @@
   <setupTask
       xsi:type="maven:MavenImportTask">
     <sourceLocator
-        rootFolder="${git.clone.location}"/>
+        rootFolder="${git.clone.location}"
+        locateNestedProjects="true"/>
   </setupTask>
   <stream name="master"
       label="Master"/>

--- a/m2e-code-quality.setup
+++ b/m2e-code-quality.setup
@@ -86,13 +86,24 @@
           rootFolder="${git.clone.location}"
           locateNestedProjects="true"/>
       <repositoryList
+          name="Photon">
+        <repository
+            url="http://download.eclipse.org/releases/photon"/>
+        <repository
+            url="http://findbugs.cs.umd.edu/eclipse/"/>
+        <repository
+            url="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
+        <repository
+            url="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
+      </repositoryList>
+      <repositoryList
           name="Oxygen">
         <repository
             url="http://download.eclipse.org/releases/oxygen"/>
         <repository
             url="http://findbugs.cs.umd.edu/eclipse/"/>
         <repository
-            url="http://eclipse-cs.sf.net/update"/>
+            url="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
         <repository
             url="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
         <repository
@@ -105,7 +116,7 @@
         <repository
             url="http://findbugs.cs.umd.edu/eclipse/"/>
         <repository
-            url="http://eclipse-cs.sf.net/update"/>
+            url="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
         <repository
             url="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
         <repository
@@ -118,7 +129,7 @@
         <repository
             url="http://findbugs.cs.umd.edu/eclipse/"/>
         <repository
-            url="http://eclipse-cs.sf.net/update"/>
+            url="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
         <repository
             url="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
         <repository

--- a/oxygen/oxygen.target
+++ b/oxygen/oxygen.target
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="Eclipse 4.7.x (Oxygen)" sequenceNumber="64">
-<locations>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.jdt.feature.group" version="3.13.1.v20170906-1700"/>
-<repository location="http://download.eclipse.org/releases/oxygen/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.8.0.20160921-2002"/>
-<unit id="org.eclipse.m2e.feature.feature.group" version="1.8.0.20160921-2002"/>
-<repository location="http://download.eclipse.org/technology/m2e/milestones/1.8"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="net.sourceforge.pmd.eclipse.feature.group" version="4.0.13.v20170429-1921"/>
-<repository location="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="3.0.1.20150306-5afe4d1"/>
-<repository location="http://findbugs.cs.umd.edu/eclipse/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="net.sf.eclipsecs.feature.group" version="8.0.0.201707161819"/>
-<repository location="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
-</location>
-</locations>
-<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.6"/>
+<?pde version="3.8"?>
+<target name="Eclipse 4.7.x (Oxygen)" sequenceNumber="64">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.m2e.logback.feature.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.m2e.sdk.feature.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
+			<repository location="http://download.eclipse.org/releases/oxygen"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="net.sourceforge.pmd.eclipse.feature.group" version="4.0.13.v20170429-1921"/>
+			<repository location="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="3.0.1.20150306-5afe4d1"/>
+			<repository location="http://findbugs.cs.umd.edu/eclipse/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="net.sf.eclipsecs.feature.group" version="8.0.0.201707161819"/>
+			<repository location="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
+		</location>
+	</locations>
+	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.6"/>
 </target>

--- a/photon/photon.target
+++ b/photon/photon.target
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="Eclipse 4.8.x (Photon)" sequenceNumber="64">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.m2e.logback.feature.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.m2e.sdk.feature.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
+			<repository location="http://download.eclipse.org/releases/photon"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="0.0.0"/>
+			<repository location="http://findbugs.cs.umd.edu/eclipse/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<unit id="net.sf.eclipsecs.feature.group" version="0.0.0"/>
+			<repository location="http://eclipse-cs.sf.net/update"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<unit id="net.sourceforge.pmd.eclipse.feature.group" version="0.0.0"/>
+			<repository location="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
+		</location>
+	</locations>
+	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.6"/>
+</target>

--- a/photon/photon.target
+++ b/photon/photon.target
@@ -2,7 +2,7 @@
 <?pde version="3.8"?>
 <target name="Eclipse 4.8.x (Photon)" sequenceNumber="64">
 	<locations>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.m2e.logback.feature.feature.group" version="0.0.0"/>
@@ -10,18 +10,17 @@
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 			<repository location="http://download.eclipse.org/releases/photon"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-			<unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="0.0.0"/>
-			<repository location="http://findbugs.cs.umd.edu/eclipse/"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-			<unit id="net.sf.eclipsecs.feature.group" version="0.0.0"/>
-			<repository location="http://eclipse-cs.sf.net/update"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="net.sourceforge.pmd.eclipse.feature.group" version="0.0.0"/>
 			<repository location="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
 		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="0.0.0"/>
+			<repository location="http://findbugs.cs.umd.edu/eclipse/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="net.sf.eclipsecs.feature.group" version="0.0.0"/>
+			<repository location="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
+		</location>
 	</locations>
-	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.6"/>
 </target>

--- a/photon/pom.xml
+++ b/photon/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.basistech.m2e-code-quality</groupId>
+		<artifactId>m2e-code-quality-plugins</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>photon</artifactId>
+	<packaging>eclipse-target-definition</packaging>
+	<name>Photon Target Definition</name>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <module>com.basistech.m2e.code.quality.pmd</module>
         <module>com.basistech.m2e.code.quality.pmd.feature</module>
         <module>com.basistech.m2e.code.quality.site</module>
+		<module>photon</module>
         <module>oxygen</module>
         <module>neon</module>
         <module>mars</module>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <module>com.basistech.m2e.code.quality.pmd</module>
         <module>com.basistech.m2e.code.quality.pmd.feature</module>
         <module>com.basistech.m2e.code.quality.site</module>
-		<module>photon</module>
+        <module>photon</module>
         <module>oxygen</module>
         <module>neon</module>
         <module>mars</module>


### PR DESCRIPTION
m2e-code-quality plugins limited required 'org.eclipse.m2e.*' bundles to a max version 1.9.0. 

- Changed the limits to M2E version used in Photon (1.10.0)
- Added Photon module and target definition
- Reworked PMD plugin compilation problems due to a changed API in the latest PMD version