### PR TITLE
Do not touch files if not needed

### DIFF
--- a/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/MavenPluginConfigurationTranslator.java
+++ b/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/MavenPluginConfigurationTranslator.java
@@ -22,9 +22,7 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.net.URI;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -106,8 +104,7 @@ public class MavenPluginConfigurationTranslator
 		final Path headerFile = workingDirectory
 		        .resolve("checkstyle-header-" + getExecutionId() + ".txt");
 		try (InputStream inputStream = headerLocation.openStream()) {
-			Files.copy(inputStream, headerFile,
-			        StandardCopyOption.REPLACE_EXISTING);
+			copyIfChanged(inputStream, headerFile);
 		} catch (final IOException e) {
 			LOG.error("Could not copy header file {}", headerLocation, e);
 			throw new CheckstylePluginException(
@@ -126,8 +123,7 @@ public class MavenPluginConfigurationTranslator
 		final Path suppressionsFile = workingDirectory.resolve(
 		        "checkstyle-suppressions-" + getExecutionId() + ".xml");
 		try (InputStream inputStream = suppressionsLocation.openStream()) {
-			Files.copy(inputStream, suppressionsFile,
-			        StandardCopyOption.REPLACE_EXISTING);
+			copyIfChanged(inputStream, suppressionsFile);
 		} catch (final IOException e) {
 			LOG.error("Could not copy suppressions file {}",
 			        suppressionsLocation, e);

--- a/com.basistech.m2e.code.quality.shared/src/main/java/com/basistech/m2e/code/quality/shared/AbstractMavenPluginConfigurationTranslator.java
+++ b/com.basistech.m2e.code.quality.shared/src/main/java/com/basistech/m2e/code/quality/shared/AbstractMavenPluginConfigurationTranslator.java
@@ -1,8 +1,13 @@
 package com.basistech.m2e.code.quality.shared;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Collections;
 import java.util.List;
 
@@ -11,8 +16,7 @@ import org.apache.maven.model.ConfigurationContainer;
 import org.apache.maven.model.PluginExecution;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.io.URLInputStreamFacade;
+import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
@@ -116,9 +120,8 @@ public class AbstractMavenPluginConfigurationTranslator {
 		// copy the file to new location
 		final File newLocationFile =
 		        new File(this.project.getLocationURI().getPath(), newLocation);
-		try {
-			FileUtils.copyStreamToFile(new URLInputStreamFacade(urlResc),
-			        newLocationFile);
+		try (InputStream inputStream = urlResc.openStream()) {
+			copyIfChanged(inputStream, newLocationFile.toPath());
 		} catch (final IOException ex) {
 			throw new ConfigurationException(String.format(
 			        "could not copy resource [%s] to [%s], reason [%s]",
@@ -138,6 +141,26 @@ public class AbstractMavenPluginConfigurationTranslator {
 	protected URL resolveLocation(String resc) {
 		Preconditions.checkNotNull(resc);
 		return this.resourceResolver.resolveLocation(resc);
+	}
+
+	protected void copyIfChanged(InputStream input, Path output) throws IOException {
+		InputStream source = input;
+		if (Files.exists(output)) {
+			byte[] fileContent = IOUtil.toByteArray(input);
+			ByteArrayInputStream bufferedInput = new ByteArrayInputStream(fileContent);
+
+			// compare content first
+			try (InputStream outputContent = Files.newInputStream(output)) {
+				if (IOUtil.contentEquals(bufferedInput, outputContent)) {
+					return;
+				}
+			}
+
+			// rewind input and use it
+			bufferedInput.reset();
+			source = bufferedInput;
+		}
+		Files.copy(source, output, StandardCopyOption.REPLACE_EXISTING);
 	}
 
 	public String getExecutionId() {

--- a/com.basistech.m2e.code.quality.shared/src/main/java/com/basistech/m2e/code/quality/shared/EclipseConfigManager.java
+++ b/com.basistech.m2e.code.quality.shared/src/main/java/com/basistech/m2e/code/quality/shared/EclipseConfigManager.java
@@ -76,6 +76,12 @@ public class EclipseConfigManager {
 		// We have to explicitly add the nature.
 		final IProjectDescription desc = project.getDescription();
 		final String[] natures = desc.getNatureIds();
+		for (int i = 0; i < natures.length; i++) {
+			if (natureId.equals(natures[i])) {
+				// already configured
+				return;
+			}
+		}
 		final String[] newNatures = Arrays.copyOf(natures, natures.length + 1);
 		newNatures[natures.length] = natureId;
 		desc.setNatureIds(newNatures);


### PR DESCRIPTION
While optimizing a very big Eclipse workspace we noticed lots of resource changed coming from m2e-code-quality, that did not actually change any file's content. As every resource change triggers an Auto-Build this is quite expensive. Instead, we check before writing if there's an actual change in the contents.