### PR TITLE
Just get a classloader for the Mojo, no need for an actual instance

### DIFF
--- a/com.basistech.m2e.code.quality.shared/src/main/java/com/basistech/m2e/code/quality/shared/AbstractMavenPluginProjectConfigurator.java
+++ b/com.basistech.m2e.code.quality.shared/src/main/java/com/basistech/m2e/code/quality/shared/AbstractMavenPluginProjectConfigurator.java
@@ -24,9 +24,12 @@ import java.util.Map;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
-import org.apache.maven.plugin.Mojo;
+import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.PluginManagerException;
+import org.apache.maven.plugin.PluginResolutionException;
 import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
@@ -35,14 +38,18 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.ArtifactKey;
 import org.eclipse.m2e.core.embedder.IMaven;
+import org.eclipse.m2e.core.internal.embedder.MavenImpl;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.IMavenProjectRegistry;
 import org.eclipse.m2e.core.project.MavenProjectChangedEvent;
 import org.eclipse.m2e.core.project.configurator.AbstractProjectConfigurator;
 import org.eclipse.m2e.core.project.configurator.ProjectConfigurationRequest;
+import org.osgi.framework.FrameworkUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,6 +62,7 @@ import com.google.common.base.Preconditions;
  * plugin configuration.
  * 
  */
+@SuppressWarnings("restriction")
 public abstract class AbstractMavenPluginProjectConfigurator
         extends AbstractProjectConfigurator {
 
@@ -303,18 +311,22 @@ public abstract class AbstractMavenPluginProjectConfigurator
 			}
 		}
 		try {
-			final Mojo configuredMojo =
-			        mvn.getConfiguredMojo(session, mojoExecution, Mojo.class);
-			mvn.releaseMojo(configuredMojo, mojoExecution);
-		} catch (CoreException e) {
-			if (pluginDepencyProjectLocations.isEmpty()) {
-				throw e;
-			}
-			LOG.trace("Could not get mojo", e);
+			// we want just the classpath of the Mojo to load resources from it
+			BuildPluginManager buildPluginManager = ((MavenImpl)mvn)
+					.lookupComponent(BuildPluginManager.class);
+			ClassRealm pluginRealm = buildPluginManager.getPluginRealm(session,
+					mojoExecution.getMojoDescriptor().getPluginDescriptor());
+			return new ResourceResolver(pluginRealm, projectLocation,
+					pluginDepencyProjectLocations);
+		} catch (PluginResolutionException | PluginManagerException e) {
+			throw new CoreException(new Status(IStatus.ERROR,
+					FrameworkUtil
+						.getBundle(AbstractMavenPluginProjectConfigurator.class)
+						.getSymbolicName(),
+					"Failed to access classpath of mojo " 
+						+ mojoExecution.getMojoDescriptor().getId(), 
+					e));
 		}
-		return new ResourceResolver(mojoExecution.getMojoDescriptor()
-		        .getPluginDescriptor().getClassRealm(), projectLocation,
-		        pluginDepencyProjectLocations);
 	}
 
 	private MavenPluginWrapper getMavenPlugin(final IProgressMonitor monitor,


### PR DESCRIPTION
In big workspaces we noticed strange classloading errors in Eclipse, which result from Mojo instantiated for the ResourceResolver. As the Mojo instance is not needed at all (just it's classpath), we changed it to not actually create instances of the Mojo. Unfortunately, some internal m2e API is needed for this.