### PR TITLE
Support <skip> configuration for findbugs/spotbugs like for checkstyle

### DIFF
--- a/com.basistech.m2e.code.quality.findbugs/src/main/java/com/basistech/m2e/code/quality/findbugs/EclipseFindbugsProjectConfigurator.java
+++ b/com.basistech.m2e.code.quality.findbugs/src/main/java/com/basistech/m2e/code/quality/findbugs/EclipseFindbugsProjectConfigurator.java
@@ -92,12 +92,16 @@ public class EclipseFindbugsProjectConfigurator
 				return;
 			}
 			prefs = this.buildFindbugsPreferences(mavenFindbugsConfig);
-			final EclipseFindbugsConfigManager fbPluginNature =
-			        EclipseFindbugsConfigManager.newInstance(project);
-			// Add the builder and nature
-			fbPluginNature.configure(monitor);
-			FindbugsPlugin.saveUserPreferences(project, prefs);
-			FindbugsPlugin.setProjectSettingsEnabled(project, null, true);
+			if (!mavenFindbugsConfig.isSkip()) {
+				final EclipseFindbugsConfigManager fbPluginNature =
+						EclipseFindbugsConfigManager.newInstance(project);
+				// Add the builder and nature
+				fbPluginNature.configure(monitor);
+				FindbugsPlugin.saveUserPreferences(project, prefs);
+				FindbugsPlugin.setProjectSettingsEnabled(project, null, true);
+			} else {
+				unconfigureEclipsePlugin(project, monitor);
+			}
 		} catch (final CoreException ex) {
 			LOG.error(ex.getLocalizedMessage(), ex);
 		}

--- a/com.basistech.m2e.code.quality.findbugs/src/main/java/com/basistech/m2e/code/quality/findbugs/FindbugsEclipseConstants.java
+++ b/com.basistech.m2e.code.quality.findbugs/src/main/java/com/basistech/m2e/code/quality/findbugs/FindbugsEclipseConstants.java
@@ -41,6 +41,7 @@ public final class FindbugsEclipseConstants {
 	public static final String EXCLUDE_FILTER_FILE = "excludeFilterFile";
 	public static final String INCLUDE_FILTER_FILE = "includeFilterFile";
 	public static final String MAX_RANK = "maxRank";
+	public static final String SKIP = "skip";
 
 	private FindbugsEclipseConstants() {
 		// no instantiation.

--- a/com.basistech.m2e.code.quality.findbugs/src/main/java/com/basistech/m2e/code/quality/findbugs/MavenPluginConfigurationTranslator.java
+++ b/com.basistech.m2e.code.quality.findbugs/src/main/java/com/basistech/m2e/code/quality/findbugs/MavenPluginConfigurationTranslator.java
@@ -29,6 +29,7 @@ import static com.basistech.m2e.code.quality.findbugs.FindbugsEclipseConstants.O
 import static com.basistech.m2e.code.quality.findbugs.FindbugsEclipseConstants.PRIORITY;
 import static com.basistech.m2e.code.quality.findbugs.FindbugsEclipseConstants.THRESHOLD;
 import static com.basistech.m2e.code.quality.findbugs.FindbugsEclipseConstants.VISITORS;
+import static com.basistech.m2e.code.quality.findbugs.FindbugsEclipseConstants.SKIP;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -74,6 +75,10 @@ public class MavenPluginConfigurationTranslator extends AbstractMavenPluginConfi
 	        final MojoExecution execution, final IProject project,
 	        final IProgressMonitor monitor) throws CoreException {
 		super(maven, session, mavenProject, execution, project, monitor);
+	}
+
+	public boolean isSkip() throws CoreException {
+		return getParameterValue(SKIP, Boolean.class, Boolean.FALSE);
 	}
 
 	public void setIncludeFilterFiles(final UserPreferences prefs)

--- a/com.basistech.m2e.code.quality.spotbugs/src/main/java/com/basistech/m2e/code/quality/spotbugs/EclipseSpotbugsProjectConfigurator.java
+++ b/com.basistech.m2e.code.quality.spotbugs/src/main/java/com/basistech/m2e/code/quality/spotbugs/EclipseSpotbugsProjectConfigurator.java
@@ -87,12 +87,16 @@ public class EclipseSpotbugsProjectConfigurator
 				return;
 			}
 			prefs = this.buildSpotbugsPreferences(mavenSpotbugsConfig);
-			final EclipseSpotbugsConfigManager fbPluginNature =
-			        EclipseSpotbugsConfigManager.newInstance(project);
-			// Add the builder and nature
-			fbPluginNature.configure(monitor);
-			FindbugsPlugin.saveUserPreferences(project, prefs);
-			FindbugsPlugin.setProjectSettingsEnabled(project, null, true);
+			if (!mavenSpotbugsConfig.isSkip()) {
+				final EclipseSpotbugsConfigManager fbPluginNature =
+				        EclipseSpotbugsConfigManager.newInstance(project);
+				// Add the builder and nature
+				fbPluginNature.configure(monitor);
+				FindbugsPlugin.saveUserPreferences(project, prefs);
+				FindbugsPlugin.setProjectSettingsEnabled(project, null, true);
+			} else {
+				unconfigureEclipsePlugin(project, monitor);
+			}
 		} catch (final CoreException ex) {
 			LOG.error(ex.getLocalizedMessage(), ex);
 		}

--- a/com.basistech.m2e.code.quality.spotbugs/src/main/java/com/basistech/m2e/code/quality/spotbugs/MavenPluginConfigurationTranslator.java
+++ b/com.basistech.m2e.code.quality.spotbugs/src/main/java/com/basistech/m2e/code/quality/spotbugs/MavenPluginConfigurationTranslator.java
@@ -29,6 +29,7 @@ import static com.basistech.m2e.code.quality.spotbugs.SpotbugsEclipseConstants.O
 import static com.basistech.m2e.code.quality.spotbugs.SpotbugsEclipseConstants.PRIORITY;
 import static com.basistech.m2e.code.quality.spotbugs.SpotbugsEclipseConstants.THRESHOLD;
 import static com.basistech.m2e.code.quality.spotbugs.SpotbugsEclipseConstants.VISITORS;
+import static com.basistech.m2e.code.quality.spotbugs.SpotbugsEclipseConstants.SKIP;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -74,6 +75,10 @@ public class MavenPluginConfigurationTranslator extends AbstractMavenPluginConfi
 	        final MojoExecution execution, final IProject project,
 	        final IProgressMonitor monitor) throws CoreException {
 		super(maven, session, mavenProject, execution, project, monitor);
+	}
+
+	public boolean isSkip() throws CoreException {
+		return getParameterValue(SKIP, Boolean.class, Boolean.FALSE);
 	}
 
 	public void setIncludeFilterFiles(final UserPreferences prefs)

--- a/com.basistech.m2e.code.quality.spotbugs/src/main/java/com/basistech/m2e/code/quality/spotbugs/SpotbugsEclipseConstants.java
+++ b/com.basistech.m2e.code.quality.spotbugs/src/main/java/com/basistech/m2e/code/quality/spotbugs/SpotbugsEclipseConstants.java
@@ -37,6 +37,7 @@ public final class SpotbugsEclipseConstants {
 	public static final String EXCLUDE_FILTER_FILE = "excludeFilterFile";
 	public static final String INCLUDE_FILTER_FILE = "includeFilterFile";
 	public static final String MAX_RANK = "maxRank";
+	public static final String SKIP = "skip";
 
 	private SpotbugsEclipseConstants() {
 		// no instantiation.


### PR DESCRIPTION
This allows the user to specify whether Findbugs/Spotbugs is run during each build or just on demand (the `<skip>` can be put in a profile that is set for m2e only).