### PR TITLE
Add Photon target

### DIFF
--- a/m2e-code-quality.setup
+++ b/m2e-code-quality.setup
@@ -86,6 +86,21 @@
           rootFolder="${git.clone.location}"
           locateNestedProjects="true"/>
       <repositoryList
+          name="Photon">
+        <repository
+            url="http://download.eclipse.org/releases/photon"/>
+        <repository
+            url="https://spotbugs.github.io/eclipse/"/>
+        <repository
+            url="http://findbugs.cs.umd.edu/eclipse/"/>
+        <repository
+            url="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
+        <repository
+            url="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
+        <repository
+            url="http://download.eclipse.org/technology/m2e/milestones/1.9"/>
+      </repositoryList>
+      <repositoryList
           name="Oxygen">
         <repository
             url="http://download.eclipse.org/releases/oxygen"/>
@@ -94,7 +109,7 @@
         <repository
             url="http://findbugs.cs.umd.edu/eclipse/"/>
         <repository
-            url="http://eclipse-cs.sf.net/update"/>
+            url="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
         <repository
             url="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
         <repository
@@ -109,7 +124,7 @@
         <repository
             url="https://spotbugs.github.io/eclipse/"/>
         <repository
-            url="http://eclipse-cs.sf.net/update"/>
+            url="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
         <repository
             url="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
         <repository
@@ -124,7 +139,7 @@
         <repository
             url="https://spotbugs.github.io/eclipse/"/>
         <repository
-            url="http://eclipse-cs.sf.net/update"/>
+            url="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
         <repository
             url="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
         <repository

--- a/photon/photon.target
+++ b/photon/photon.target
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="Eclipse 4.8.x (Photon)">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
+			<repository location="http://download.eclipse.org/releases/photon"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.m2e.sdk.feature.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
+			<repository location="http://download.eclipse.org/technology/m2e/milestones/1.9"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="net.sourceforge.pmd.eclipse.feature.group" version="4.0.17.v20180801-1551"/>
+			<repository location="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="3.0.1.20150306-5afe4d1"/>
+			<repository location="http://findbugs.cs.umd.edu/eclipse/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="com.github.spotbugs.plugin.eclipse.feature.group" version="3.1.7.r201809130347-03f0119"/>
+			<repository location="https://spotbugs.github.io/eclipse/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="net.sf.eclipsecs.feature.group" version="8.0.0.201707161819"/>
+			<repository location="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
+		</location>
+	</locations>
+</target>

--- a/photon/pom.xml
+++ b/photon/pom.xml
@@ -1,0 +1,11 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.basistech.m2e-code-quality</groupId>
+    <artifactId>m2e-code-quality-plugins</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>photon</artifactId>
+  <packaging>eclipse-target-definition</packaging>
+  <name>Photon Target Definition</name>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <module>oxygen</module>
         <module>neon</module>
         <module>mars</module>
+        <module>photon</module>
     </modules>
 
     <repositories>


### PR DESCRIPTION
Closes #121 

I extracted from #121 what seemed to be still relevant.

I agree with #115 that the constraint should be up to v2.

I fixed the version of the various quality control tools in the target, but let the eclipse stuffs at version `0.0.0` to always build against the latest of the Photon update site. Maybe that's a mistake, I can change that.

There is something I'm really not clear about, Eclipe build is always such a mess:
- According to #120, our current build is already compatible with Photon, so why is there a need for a specific target?
- I updated the content of the `m2e-code-quality.setup` file but I have absolutely no idea what is it for. It seems to duplicate information we can find both in the targets and in the pom.xml…
- The update sites in the pom.xml doesn't seem to even be the correct ones, for example for checkstyle.
- I couldn't find where in travis is configured the place where things are generated for the various target, I suppose this is related to #123?