### PR TITLE
Tests in x86_64 on windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,11 @@
                             <arch>x86</arch>
                         </environment>
                         <environment>
+                            <os>win32</os>
+                            <ws>win32</ws>
+                            <arch>x86_64</arch>
+                        </environment>
+                        <environment>
                             <os>linux</os>
                             <ws>gtk</ws>
                             <arch>x86_64</arch>


### PR DESCRIPTION
This is needed so that the tests can be run on 64Bit Windows, too