### PR TITLE
Use 0.0.0 version where there's a single version only

### DIFF
--- a/neon/neon.target
+++ b/neon/neon.target
@@ -15,14 +15,15 @@
 <repository location="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="3.0.1.20150306-5afe4d1"/>
+<unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="0.0.0"/>
 <repository location="http://findbugs.cs.umd.edu/eclipse/"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit"><unit id="com.github.spotbugs.plugin.eclipse.feature.group" version="3.1.7.r201809130347-03f0119"/>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="com.github.spotbugs.plugin.eclipse.feature.group" version="0.0.0"/>
 <repository location="https://spotbugs.github.io/eclipse/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="net.sf.eclipsecs.feature.group" version="8.0.0.201707161819"/>
+<unit id="net.sf.eclipsecs.feature.group" version="0.0.0"/>
 <repository location="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
 </location>
 </locations>

--- a/oxygen/oxygen.target
+++ b/oxygen/oxygen.target
@@ -15,15 +15,15 @@
 <repository location="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="3.0.1.20150306-5afe4d1"/>
+<unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="0.0.0"/>
 <repository location="http://findbugs.cs.umd.edu/eclipse/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="com.github.spotbugs.plugin.eclipse.feature.group" version="3.1.7.r201809130347-03f0119"/>
+<unit id="com.github.spotbugs.plugin.eclipse.feature.group" version="0.0.0"/>
 <repository location="https://spotbugs.github.io/eclipse/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="net.sf.eclipsecs.feature.group" version="8.0.0.201707161819"/>
+<unit id="net.sf.eclipsecs.feature.group" version="0.0.0"/>
 <repository location="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
 </location>
 </locations>

--- a/photon/photon.target
+++ b/photon/photon.target
@@ -16,15 +16,15 @@
 			<repository location="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="3.0.1.20150306-5afe4d1"/>
+			<unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="0.0.0"/>
 			<repository location="http://findbugs.cs.umd.edu/eclipse/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.github.spotbugs.plugin.eclipse.feature.group" version="3.1.7.r201809130347-03f0119"/>
+			<unit id="com.github.spotbugs.plugin.eclipse.feature.group" version="0.0.0"/>
 			<repository location="https://spotbugs.github.io/eclipse/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="net.sf.eclipsecs.feature.group" version="8.0.0.201707161819"/>
+			<unit id="net.sf.eclipsecs.feature.group" version="0.0.0"/>
 			<repository location="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
 		</location>
 	</locations>


### PR DESCRIPTION
This will prevent the build to break each time the dependent plugin is updated.