### PR TITLE
Add newer eclipse versions to oomph

### DIFF
--- a/m2e-code-quality.setup
+++ b/m2e-code-quality.setup
@@ -90,6 +90,36 @@
           rootFolder="${git.clone.location}"
           locateNestedProjects="true"/>
       <repositoryList
+          name="2018-12">
+        <repository
+            url="http://findbugs.cs.umd.edu/eclipse/"/>
+        <repository
+            url="http://download.eclipse.org/releases/2018-12"/>
+        <repository
+            url="https://spotbugs.github.io/eclipse/"/>
+        <repository
+            url="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
+        <repository
+            url="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
+        <repository
+            url="http://download.eclipse.org/technology/m2e/releases/1.9"/>
+      </repositoryList>
+      <repositoryList
+          name="2018-09">
+        <repository
+            url="http://download.eclipse.org/releases/2018-09"/>
+        <repository
+            url="http://findbugs.cs.umd.edu/eclipse/"/>
+        <repository
+            url="https://spotbugs.github.io/eclipse/"/>
+        <repository
+            url="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
+        <repository
+            url="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
+        <repository
+            url="http://download.eclipse.org/technology/m2e/releases/1.9"/>
+      </repositoryList>
+      <repositoryList
           name="Photon">
         <repository
             url="http://download.eclipse.org/releases/photon"/>


### PR DESCRIPTION
This should fix the error in #157 that ```org.eclipse.sdk.feature.group``` can't be found.