### PR TITLE
Add Automatic-Module-Name header

### DIFF
--- a/com.basistech.m2e.code.quality.checkstyle.test/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.checkstyle.test/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit,
  com.basistech.m2e.code.quality.shared.test;bundle-version="1.1.3",
  org.eclipse.m2e.tests.common
+Automatic-Module-Name: com.basistech.m2e.code.quality.checkstyle.test

--- a/com.basistech.m2e.code.quality.checkstyle/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.checkstyle/META-INF/MANIFEST.MF
@@ -27,3 +27,4 @@ Import-Package: org.apache.commons.lang,
 Bundle-Activator: com.basistech.m2e.code.quality.checkstyle.Activator
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
+Automatic-Module-Name: com.basistech.m2e.code.quality.checkstyle

--- a/com.basistech.m2e.code.quality.findbugs.test/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.findbugs.test/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit,
  com.basistech.m2e.code.quality.shared.test;bundle-version="1.1.3",
  org.eclipse.m2e.tests.common
+Automatic-Module-Name: com.basistech.m2e.code.quality.findbugs.test

--- a/com.basistech.m2e.code.quality.findbugs/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.findbugs/META-INF/MANIFEST.MF
@@ -18,3 +18,4 @@ Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,2.0.0)",
  org.slf4j.api;bundle-version="1.6.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Basis Technology Corp.
+Automatic-Module-Name: com.basistech.m2e.code.quality.findbugs

--- a/com.basistech.m2e.code.quality.pmd/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.pmd/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,2.0.0)",
  org.slf4j.api;bundle-version="1.6.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Basis Technology Corp.
+Automatic-Module-Name: com.basistech.m2e.code.quality.pmd

--- a/com.basistech.m2e.code.quality.shared.test/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.shared.test/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,2.0.0)",
  org.junit,
  org.eclipse.m2e.tests.common;visibility:=reexport
 Export-Package: com.basistech.m2e.code.quality.shared.test
+Automatic-Module-Name: com.basistech.m2e.code.quality.shared.test

--- a/com.basistech.m2e.code.quality.shared/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.shared/META-INF/MANIFEST.MF
@@ -21,6 +21,7 @@ Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.jdt.core;bundle-version="3.4.0",
  org.eclipse.core.runtime;bundle-version="3.4.0",
  org.slf4j.api;bundle-version="1.6.1"
+Automatic-Module-Name: com.basistech.m2e.code.quality.shared
 
 
 

--- a/com.basistech.m2e.code.quality.spotbugs.test/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.spotbugs.test/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit,
  com.basistech.m2e.code.quality.shared.test;bundle-version="1.1.3",
  org.eclipse.m2e.tests.common
+Automatic-Module-Name: com.basistech.m2e.code.quality.spotbugs.test

--- a/com.basistech.m2e.code.quality.spotbugs/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.spotbugs/META-INF/MANIFEST.MF
@@ -18,3 +18,4 @@ Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,2.0.0)",
  org.slf4j.api;bundle-version="1.6.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Basis Technology Corp.
+Automatic-Module-Name: com.basistech.m2e.code.quality.spotbugs


### PR DESCRIPTION
Avoid Eclipse warnings for Java 9 compatibility by adding one more
header to each manifest.