### PR TITLE
Use uppercase B in SpotBugs/FindBugs

### DIFF
--- a/com.basistech.m2e.code.quality.findbugs.feature/feature.properties
+++ b/com.basistech.m2e.code.quality.findbugs.feature/feature.properties
@@ -1,5 +1,5 @@
 # feature.properties
 # "featureName" property - name of the feature
-featureName=Findbugs Configuration for M2Eclipse
+featureName=FindBugs Configuration for M2Eclipse
 providerName=Basis Technology Corp.
-description=Findbugs Configuration for M2Eclipse
+description=FindBugs Configuration for M2Eclipse

--- a/com.basistech.m2e.code.quality.findbugs.feature/feature.xml
+++ b/com.basistech.m2e.code.quality.findbugs.feature/feature.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="com.basistech.m2e.code.quality.findbugs.feature"
-      label="Findbugs configuration plugin for M2Eclipse"
+      label="FindBugs configuration plugin for M2Eclipse"
       version="1.1.3.qualifier"
       plugin="com.basistech.m2e.code.quality.shared">
 
    <description>
-      Feature to automatically configure the Eclipse Findbugs plugin with configuration
+      Feature to automatically configure the Eclipse FindBugs plugin with configuration
 derived from the configuration of the check goal of the maven-findbugs-plugin.
    </description>
 

--- a/com.basistech.m2e.code.quality.findbugs.feature/pom.xml
+++ b/com.basistech.m2e.code.quality.findbugs.feature/pom.xml
@@ -14,6 +14,6 @@
 
     <artifactId>com.basistech.m2e.code.quality.findbugs.feature</artifactId>
     <packaging>eclipse-feature</packaging>
-    <name>M2Eclipse Project Configurator for Eclipse Findbugs Feature</name>
+    <name>M2Eclipse Project Configurator for Eclipse FindBugs Feature</name>
 
 </project>

--- a/com.basistech.m2e.code.quality.findbugs.test/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.findbugs.test/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: M2Eclipse Project Configurator for Eclipse Findbugs Tests
+Bundle-Name: M2Eclipse Project Configurator for Eclipse FindBugs Tests
 Bundle-SymbolicName: com.basistech.m2e.code.quality.findbugs.test
 Bundle-Version: 1.1.3.qualifier
 Bundle-Vendor: Basis Technology Corp.

--- a/com.basistech.m2e.code.quality.findbugs.test/pom.xml
+++ b/com.basistech.m2e.code.quality.findbugs.test/pom.xml
@@ -14,6 +14,6 @@
 
     <artifactId>com.basistech.m2e.code.quality.findbugs.test</artifactId>
     <packaging>eclipse-test-plugin</packaging>
-    <name>M2Eclipse Project Configurator for Eclipse Findbugs Tests</name>
+    <name>M2Eclipse Project Configurator for Eclipse FindBugs Tests</name>
 
 </project>

--- a/com.basistech.m2e.code.quality.findbugs/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.findbugs/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: M2Eclipse Project Configurator for Eclipse Findbugs
+Bundle-Name: M2Eclipse Project Configurator for Eclipse FindBugs
 Bundle-SymbolicName: com.basistech.m2e.code.quality.findbugs;singleton:=true
 Bundle-Version: 1.1.3.qualifier
 Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,2.0.0)",

--- a/com.basistech.m2e.code.quality.findbugs/pom.xml
+++ b/com.basistech.m2e.code.quality.findbugs/pom.xml
@@ -14,6 +14,6 @@
 
     <artifactId>com.basistech.m2e.code.quality.findbugs</artifactId>
     <packaging>eclipse-plugin</packaging>
-    <name>M2Eclipse Project Configurator for Eclipse Findbugs</name>
+    <name>M2Eclipse Project Configurator for Eclipse FindBugs</name>
 
 </project>

--- a/com.basistech.m2e.code.quality.shared/src/main/java/com/basistech/m2e/code/quality/shared/AbstractMavenPluginConfigurationTranslator.java
+++ b/com.basistech.m2e.code.quality.shared/src/main/java/com/basistech/m2e/code/quality/shared/AbstractMavenPluginConfigurationTranslator.java
@@ -100,7 +100,7 @@ public class AbstractMavenPluginConfigurationTranslator {
 	 * Copy a resource from the maven plugin configuration to a location within
 	 * the project.
 	 * <p>
-	 * This the only reference I could find on how the Findbugs Eclipse Plugin
+	 * This the only reference I could find on how the FindBugs Eclipse Plugin
 	 * configuration works.
 	 * </p>
 	 *

--- a/com.basistech.m2e.code.quality.spotbugs.feature/pom.xml
+++ b/com.basistech.m2e.code.quality.spotbugs.feature/pom.xml
@@ -14,6 +14,6 @@
 
     <artifactId>com.basistech.m2e.code.quality.spotbugs.feature</artifactId>
     <packaging>eclipse-feature</packaging>
-    <name>M2Eclipse Project Configurator for Eclipse Spotbugs Feature</name>
+    <name>M2Eclipse Project Configurator for Eclipse SpotBugs Feature</name>
 
 </project>

--- a/com.basistech.m2e.code.quality.spotbugs/pom.xml
+++ b/com.basistech.m2e.code.quality.spotbugs/pom.xml
@@ -14,6 +14,6 @@
 
     <artifactId>com.basistech.m2e.code.quality.spotbugs</artifactId>
     <packaging>eclipse-plugin</packaging>
-    <name>M2Eclipse Project Configurator for Eclipse Spotbugs</name>
+    <name>M2Eclipse Project Configurator for Eclipse SpotBugs</name>
 
 </project>


### PR DESCRIPTION
Both projects write themselves with uppercase B, therefore change this
in user visible output (e.g. feature names etc.). In contrast,
Checkstyle does not use an uppercase S.