### PR TITLE
Fix #203: Have org.apache.commons.lang in targets

### DIFF
--- a/mars/mars.target
+++ b/mars/mars.target
@@ -22,6 +22,10 @@
 <unit id="net.sf.eclipsecs.feature.group" version="6.16.0.201603042321"/>
 <repository location="http://sourceforge.net/projects/eclipse-cs/files/updatesite/6.16.0"/>
 </location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+	<unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
+	<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160221192158/repository/"/>
+</location>
 </locations>
-<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.6"/>
+<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.7"/>
 </target>

--- a/neon/neon.target
+++ b/neon/neon.target
@@ -26,6 +26,10 @@
 <unit id="net.sf.eclipsecs.feature.group" version="0.0.0"/>
 <repository location="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
 </location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+	<unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
+	<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160221192158/repository/"/>
+</location>
 </locations>
-<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.6"/>
+<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.7"/>
 </target>

--- a/oxygen/oxygen.target
+++ b/oxygen/oxygen.target
@@ -26,6 +26,10 @@
 <unit id="net.sf.eclipsecs.feature.group" version="0.0.0"/>
 <repository location="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
 </location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+	<unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
+	<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160221192158/repository/"/>
+</location>
 </locations>
-<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.6"/>
+<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.7"/>
 </target>

--- a/photon/photon.target
+++ b/photon/photon.target
@@ -1,6 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?>
-<target name="Eclipse 4.8.x (Photon)">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="Eclipse 4.8.x (Photon)">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
@@ -27,5 +25,10 @@
 			<unit id="net.sf.eclipsecs.feature.group" version="0.0.0"/>
 			<repository location="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
 		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
+			<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160221192158/repository/"/>
+		</location>
 	</locations>
+	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.7"/>
 </target>


### PR DESCRIPTION
The POM repositories and the Eclipse targets are somewhat out of sync.
As a quickfix just add the missing bundle to the Eclipse target. In the
long run I suggest to use a .target file in the Maven build, too,
instead of fetching whatever is available on the repository URLs.