### PR TITLE
fix/suppress some compiler warnings

### DIFF
--- a/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/MavenPluginConfigurationTranslator.java
+++ b/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/MavenPluginConfigurationTranslator.java
@@ -563,7 +563,7 @@ public class MavenPluginConfigurationTranslator
 
 	public static List<MavenPluginConfigurationTranslator> newInstance(
 	        final IMaven maven,
-	        final AbstractMavenPluginProjectConfigurator configurator,
+	        final AbstractMavenPluginProjectConfigurator<?> configurator,
 	        final MavenProject mavenProject,
 	        final MavenPluginWrapper mavenPlugin, final IProject project,
 	        final IProgressMonitor monitor, final MavenSession session)

--- a/com.basistech.m2e.code.quality.pmd/src/main/java/com/basistech/m2e/code/quality/pmd/MavenPluginConfigurationTranslator.java
+++ b/com.basistech.m2e.code.quality.pmd/src/main/java/com/basistech/m2e/code/quality/pmd/MavenPluginConfigurationTranslator.java
@@ -28,7 +28,6 @@ import java.util.Map;
 
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.ConfigurationContainer;
-import org.apache.maven.model.PluginConfiguration;
 import org.apache.maven.model.PluginExecution;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;

--- a/com.basistech.m2e.code.quality.shared/src/main/java/com/basistech/m2e/code/quality/shared/AbstractMavenPluginProjectConfigurator.java
+++ b/com.basistech.m2e.code.quality.shared/src/main/java/com/basistech/m2e/code/quality/shared/AbstractMavenPluginProjectConfigurator.java
@@ -352,10 +352,12 @@ public abstract class AbstractMavenPluginProjectConfigurator<N extends IProjectN
 	 * Get the currently configured nature in the project
 	 * @return <code>null</code> if the nature is not active.
 	 */
+	@SuppressWarnings("unchecked")
 	protected N getNature(final IProject project) throws CoreException {
 		return (N) project.getNature(natureId);
 	}
 
+	@SuppressWarnings("unchecked")
 	protected N addNature(final IProject project, final IProgressMonitor monitor)
 	        throws CoreException {
 		LOG.debug("entering configureNature");


### PR DESCRIPTION
With these changes my workspace is free of warnings, except for Java7
not being available, while the projects request Java7. If wanted, we can
also change BREE, classpath and Maven source/target to java8 to get rid
of those, too.