### PR TITLE
Handle multiple values for include/excludeFilterFile for spot/findBugs

### DIFF
--- a/com.basistech.m2e.code.quality.findbugs/src/main/java/com/basistech/m2e/code/quality/findbugs/MavenPluginConfigurationTranslator.java
+++ b/com.basistech.m2e.code.quality.findbugs/src/main/java/com/basistech/m2e/code/quality/findbugs/MavenPluginConfigurationTranslator.java
@@ -90,14 +90,16 @@ public class MavenPluginConfigurationTranslator extends AbstractMavenPluginConfi
 			LOG.debug("includeFilterFile is null");
 			return;
 		}
-		this.copyUrlResourceToProject(includeFilterFile,
+		List<String> filterFiles = this.copyUrlResourcesToProject(includeFilterFile,
 		        FB_INCLUDE_FILTER_FILE);
 		final Map<String, Boolean> curIncludeFilteredFiles =
 		        prefs.getIncludeFilterFiles();
 		final Map<String, Boolean> newIncludeFilteredFiles = new HashMap<>();
 		// Make sure we add it only once.
-		if (!curIncludeFilteredFiles.containsKey(FB_INCLUDE_FILTER_FILE)) {
-			newIncludeFilteredFiles.put(FB_INCLUDE_FILTER_FILE, Boolean.TRUE);
+		for (String filterFile : filterFiles) {
+			if (!curIncludeFilteredFiles.containsKey(filterFile)) {
+				newIncludeFilteredFiles.put(filterFile, Boolean.TRUE);
+			}
 		}
 		newIncludeFilteredFiles.putAll(curIncludeFilteredFiles);
 		prefs.setIncludeFilterFiles(newIncludeFilteredFiles);
@@ -113,14 +115,17 @@ public class MavenPluginConfigurationTranslator extends AbstractMavenPluginConfi
 			LOG.debug("excludeFilterFile is null");
 			return;
 		}
-		this.copyUrlResourceToProject(excludeFilterFile,
+
+		List<String> filterFiles = this.copyUrlResourcesToProject(excludeFilterFile,
 		        FB_EXCLUDE_FILTER_FILE);
 		final Map<String, Boolean> curExcludeFilteredFiles =
-		        prefs.getExcludeFilterFiles();
+				prefs.getExcludeFilterFiles();
 		final Map<String, Boolean> newExcludeFilteredFiles = new HashMap<>();
 		// Make sure we add it only once.
-		if (!curExcludeFilteredFiles.containsKey(FB_EXCLUDE_FILTER_FILE)) {
-			newExcludeFilteredFiles.put(FB_EXCLUDE_FILTER_FILE, Boolean.TRUE);
+		for (String filterFile : filterFiles) {
+			if (!curExcludeFilteredFiles.containsKey(filterFile)) {
+				newExcludeFilteredFiles.put(filterFile, Boolean.TRUE);
+			}
 		}
 		newExcludeFilteredFiles.putAll(curExcludeFilteredFiles);
 		prefs.setExcludeFilterFiles(newExcludeFilteredFiles);

--- a/com.basistech.m2e.code.quality.shared/src/main/java/com/basistech/m2e/code/quality/shared/AbstractMavenPluginConfigurationTranslator.java
+++ b/com.basistech.m2e.code.quality.shared/src/main/java/com/basistech/m2e/code/quality/shared/AbstractMavenPluginConfigurationTranslator.java
@@ -8,6 +8,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -167,6 +168,38 @@ public class AbstractMavenPluginConfigurationTranslator {
 			source = bufferedInput;
 		}
 		Files.copy(source, output, StandardCopyOption.REPLACE_EXISTING);
+	}
+
+	/**
+	 * Copy a comma separated list of resource names, separated by comma. Will append an index to the basename if there
+	 * is more than a single element. Also, for backwards compatibility the first element will not have an index
+	 * appended.
+	 * @param resc
+	 *            the resource location as read from the plugin configuration. Can be a single resource or a comma 
+	 *            separated list of resources
+	 * @param newLocationBase
+	 *            the new location relative to the project root.
+	 * @return a list of new locations relative to the project root
+	 * @throws NullPointerException
+	 *             If any of the arguments are {@code null}.
+	 * @throws ConfigurationException
+	 *             If an error occurred during the resolution of the resource or
+	 *             copy to the new location failed.
+	 * @see #copyUrlResourceToProject(String, String)
+	 */
+	protected List<String> copyUrlResourcesToProject(String resc, String newLocationBase) {
+		Preconditions.checkNotNull(resc);
+		Preconditions.checkNotNull(newLocationBase);
+
+		List<String> result = new ArrayList<String>();
+		String[] resourceList = resc.split(",");
+		for (int i=0; i<resourceList.length; ++i) {
+			String suffix = i == 0 ? "" : "." + i;
+			String target = newLocationBase + suffix; 
+			copyUrlResourceToProject(resourceList[i], target);
+			result.add(target);
+		}
+		return result;
 	}
 
 	public String getExecutionId() {

--- a/com.basistech.m2e.code.quality.spotbugs/src/main/java/com/basistech/m2e/code/quality/spotbugs/MavenPluginConfigurationTranslator.java
+++ b/com.basistech.m2e.code.quality.spotbugs/src/main/java/com/basistech/m2e/code/quality/spotbugs/MavenPluginConfigurationTranslator.java
@@ -90,14 +90,16 @@ public class MavenPluginConfigurationTranslator extends AbstractMavenPluginConfi
 			LOG.debug("includeFilterFile is null");
 			return;
 		}
-		this.copyUrlResourceToProject(includeFilterFile,
+		List<String> filterFiles = this.copyUrlResourcesToProject(includeFilterFile,
 		        FB_INCLUDE_FILTER_FILE);
 		final Map<String, Boolean> curIncludeFilteredFiles =
 		        prefs.getIncludeFilterFiles();
 		final Map<String, Boolean> newIncludeFilteredFiles = new HashMap<>();
 		// Make sure we add it only once.
-		if (!curIncludeFilteredFiles.containsKey(FB_INCLUDE_FILTER_FILE)) {
-			newIncludeFilteredFiles.put(FB_INCLUDE_FILTER_FILE, Boolean.TRUE);
+		for (String filterFile : filterFiles) {
+			if (!curIncludeFilteredFiles.containsKey(filterFile)) {
+				newIncludeFilteredFiles.put(filterFile, Boolean.TRUE);
+			}
 		}
 		newIncludeFilteredFiles.putAll(curIncludeFilteredFiles);
 		prefs.setIncludeFilterFiles(newIncludeFilteredFiles);
@@ -113,14 +115,15 @@ public class MavenPluginConfigurationTranslator extends AbstractMavenPluginConfi
 			LOG.debug("excludeFilterFile is null");
 			return;
 		}
-		this.copyUrlResourceToProject(excludeFilterFile,
+		List<String> filterFiles = this.copyUrlResourcesToProject(excludeFilterFile,
 		        FB_EXCLUDE_FILTER_FILE);
 		final Map<String, Boolean> curExcludeFilteredFiles =
 		        prefs.getExcludeFilterFiles();
 		final Map<String, Boolean> newExcludeFilteredFiles = new HashMap<>();
-		// Make sure we add it only once.
-		if (!curExcludeFilteredFiles.containsKey(FB_EXCLUDE_FILTER_FILE)) {
-			newExcludeFilteredFiles.put(FB_EXCLUDE_FILTER_FILE, Boolean.TRUE);
+		for (String filterFile : filterFiles) {
+			if (!curExcludeFilteredFiles.containsKey(filterFile)) {
+				newExcludeFilteredFiles.put(filterFile, Boolean.TRUE);
+			}
 		}
 		newExcludeFilteredFiles.putAll(curExcludeFilteredFiles);
 		prefs.setExcludeFilterFiles(newExcludeFilteredFiles);


### PR DESCRIPTION
While the Maven plugin can handle a comma separated list of files and
the Eclipse plugin can also have more than one file, the configuration
did not handle this case.
