### PR TITLE
New PMD Eclipse Plugin update site

### DIFF
--- a/m2e-code-quality.setup
+++ b/m2e-code-quality.setup
@@ -100,7 +100,7 @@
         <repository
             url="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
         <repository
-            url="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
+            url="https://pmd.github.io/pmd-eclipse-plugin-p2-site/"/>
         <repository
             url="http://download.eclipse.org/technology/m2e/releases/1.9"/>
       </repositoryList>
@@ -115,7 +115,7 @@
         <repository
             url="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
         <repository
-            url="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
+            url="https://pmd.github.io/pmd-eclipse-plugin-p2-site/"/>
         <repository
             url="http://download.eclipse.org/technology/m2e/releases/1.9"/>
       </repositoryList>
@@ -130,7 +130,7 @@
         <repository
             url="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
         <repository
-            url="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
+            url="https://pmd.github.io/pmd-eclipse-plugin-p2-site/"/>
         <repository
             url="http://download.eclipse.org/technology/m2e/milestones/1.9"/>
       </repositoryList>
@@ -145,7 +145,7 @@
         <repository
             url="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
         <repository
-            url="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
+            url="https://pmd.github.io/pmd-eclipse-plugin-p2-site/"/>
         <repository
             url="http://download.eclipse.org/technology/m2e/milestones/1.8"/>
       </repositoryList>
@@ -160,7 +160,7 @@
         <repository
             url="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
         <repository
-            url="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
+            url="https://pmd.github.io/pmd-eclipse-plugin-p2-site/"/>
         <repository
             url="http://download.eclipse.org/technology/m2e/milestones/1.7"/>
       </repositoryList>
@@ -175,7 +175,7 @@
         <repository
             url="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
         <repository
-            url="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
+            url="https://pmd.github.io/pmd-eclipse-plugin-p2-site/"/>
         <repository
             url="http://download.eclipse.org/technology/m2e/milestones/1.6"/>
       </repositoryList>

--- a/mars/mars.target
+++ b/mars/mars.target
@@ -15,8 +15,8 @@
 <repository location="https://pmd.github.io/pmd-eclipse-plugin-p2-site/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="2.0.0.20111221"/>
-<repository location="http://m2e-code-quality.github.com/m2e-code-quality/findbugs-p2-repository"/>
+<unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="0.0.0"/>
+<repository location="https://findbugs.cs.umd.edu/eclipse/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="net.sf.eclipsecs.feature.group" version="6.16.0.201603042321"/>

--- a/mars/mars.target
+++ b/mars/mars.target
@@ -11,8 +11,8 @@
 <repository location="http://download.eclipse.org/technology/m2e/milestones/1.6"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="net.sourceforge.pmd.eclipse.feature.group" version="4.0.8.v20151204-2156"/>
-<repository location="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
+<unit id="net.sourceforge.pmd.eclipse.feature.group" version="0.0.0"/>
+<repository location="https://pmd.github.io/pmd-eclipse-plugin-p2-site/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="2.0.0.20111221"/>

--- a/neon/neon.target
+++ b/neon/neon.target
@@ -11,8 +11,8 @@
 <repository location="http://download.eclipse.org/technology/m2e/milestones/1.7"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="net.sourceforge.pmd.eclipse.feature.group" version="4.0.13.v20170429-1921"/>
-<repository location="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
+<unit id="net.sourceforge.pmd.eclipse.feature.group" version="0.0.0"/>
+<repository location="https://pmd.github.io/pmd-eclipse-plugin-p2-site/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="0.0.0"/>

--- a/oxygen/oxygen.target
+++ b/oxygen/oxygen.target
@@ -11,8 +11,8 @@
 <repository location="http://download.eclipse.org/technology/m2e/milestones/1.8"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="net.sourceforge.pmd.eclipse.feature.group" version="4.0.13.v20170429-1921"/>
-<repository location="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
+<unit id="net.sourceforge.pmd.eclipse.feature.group" version="0.0.0"/>
+<repository location="https://pmd.github.io/pmd-eclipse-plugin-p2-site/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="0.0.0"/>

--- a/photon/photon.target
+++ b/photon/photon.target
@@ -10,8 +10,8 @@
 			<repository location="http://download.eclipse.org/technology/m2e/milestones/1.9"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="net.sourceforge.pmd.eclipse.feature.group" version="4.0.17.v20180801-1551"/>
-			<repository location="https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/"/>
+			<unit id="net.sourceforge.pmd.eclipse.feature.group" version="0.0.0"/>
+			<repository location="https://pmd.github.io/pmd-eclipse-plugin-p2-site/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="0.0.0"/>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <updatesite.m2e>http://download.eclipse.org/technology/m2e/releases</updatesite.m2e>
         <updatesite.eclipse>http://download.eclipse.org/releases/photon</updatesite.eclipse>
         <updatesite.cs>http://eclipse-cs.sf.net/update</updatesite.cs>
-        <updatesite.pmd>https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/</updatesite.pmd>
+        <updatesite.pmd>https://pmd.github.io/pmd-eclipse-plugin-p2-site/</updatesite.pmd>
         <updatesite.findbugs>http://findbugs.cs.umd.edu/eclipse/</updatesite.findbugs>
         <updatesite.spotbugs>https://spotbugs.github.io/eclipse/</updatesite.spotbugs>
         <updatesite.orbit>http://download.eclipse.org/tools/orbit/downloads/drops/${orbit.version}/repository/</updatesite.orbit>


### PR DESCRIPTION
The Update site of [PMD Eclipse Plugin](https://github.com/pmd/pmd-eclipse-plugin) moved from <https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/> to <https://pmd.github.io/pmd-eclipse-plugin-p2-site/>.
See also https://github.com/pmd/pmd-eclipse-plugin/issues/140.