### PR TITLE
Fix checkstyle update site

### DIFF
--- a/neon/neon.target
+++ b/neon/neon.target
@@ -24,7 +24,7 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="net.sf.eclipsecs.feature.group" version="0.0.0"/>
-<repository location="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
+<repository location="https://checkstyle.org/eclipse-cs-update-site/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>

--- a/oxygen/oxygen.target
+++ b/oxygen/oxygen.target
@@ -24,7 +24,7 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="net.sf.eclipsecs.feature.group" version="0.0.0"/>
-<repository location="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
+<repository location="https://checkstyle.org/eclipse-cs-update-site/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>

--- a/photon/photon.target
+++ b/photon/photon.target
@@ -23,7 +23,7 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="net.sf.eclipsecs.feature.group" version="0.0.0"/>
-			<repository location="https://dl.bintray.com/eclipse-cs/eclipse-cs/8.0.0/"/>
+			<repository location="https://checkstyle.org/eclipse-cs-update-site/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
         <updatesite.m2e>http://download.eclipse.org/technology/m2e/releases</updatesite.m2e>
         <updatesite.eclipse>http://download.eclipse.org/releases/photon</updatesite.eclipse>
-        <updatesite.cs>http://eclipse-cs.sf.net/update</updatesite.cs>
+        <updatesite.cs>https://checkstyle.org/eclipse-cs-update-site/</updatesite.cs>
         <updatesite.pmd>https://pmd.github.io/pmd-eclipse-plugin-p2-site/</updatesite.pmd>
         <updatesite.findbugs>http://findbugs.cs.umd.edu/eclipse/</updatesite.findbugs>
         <updatesite.spotbugs>https://spotbugs.github.io/eclipse/</updatesite.spotbugs>


### PR DESCRIPTION
The new checkstyle update site is https://checkstyle.org/eclipse-cs-update-site/

This PR should make the build work again.