### PR TITLE
Release automation with github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
 
       - name: Publish update site
-        if: ${{ runner.os == 'Linux' && github.event_name == 'push' && github.repository == 'm2e-code-quality/m2e-code-quality' && github.ref == 'refs/heads/develop' }}
+        if: ${{ runner.os == 'Linux' && github.event_name == 'push' && github.repository == 'm2e-code-quality/m2e-code-quality' }}
         shell: bash
         run: tools/publish-update-site.sh
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,13 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
 
+      - name: Prepare release
+        if: ${{ runner.os == 'Linux' && github.event_name == 'push' && github.repository == 'm2e-code-quality/m2e-code-quality' && startsWith(github.ref, 'refs/tags/') }}
+        shell: bash
+        run: tools/prepare_release.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build with Maven
         uses: GabrielBB/xvfb-action@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,3 +60,10 @@ jobs:
         run: tools/publish-update-site.sh
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_SITE_TOKEN }}
+
+      - name: Publish release
+        if: ${{ runner.os == 'Linux' && github.event_name == 'push' && github.repository == 'm2e-code-quality/m2e-code-quality' && startsWith(github.ref, 'refs/tags/') }}
+        shell: bash
+        run: tools/release.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,8 @@ jobs:
         shell: bash
         run: tools/publish-update-site.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.PUBLISH_SITE_TOKEN }}
+          PUBLISH_SITE_TOKEN: ${{ secrets.PUBLISH_SITE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish release
         if: ${{ runner.os == 'Linux' && github.event_name == 'push' && github.repository == 'm2e-code-quality/m2e-code-quality' && startsWith(github.ref, 'refs/tags/') }}

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-gem "github_changelog_generator"
+# bleeding edge from git
+#gem 'github_changelog_generator', :git => 'https://github.com/github-changelog-generator/github-changelog-generator.git', branch: 'master'
+
+
+gem 'github_changelog_generator'

--- a/doc/release.md
+++ b/doc/release.md
@@ -1,11 +1,10 @@
-m2e-code-quality build and release
-==================================
+# m2e-code-quality build and release
 
 m2e-code-quality is built with Tycho.
 
 To make a release:
 
-1. Run a build. Use Apache Maven version 3.0.3 or newer. Always run `mvn clean install`;
+1. Run a build. Always run `./mvnw clean install`;
 Tycho has some stupid bug that goes off if you don't start from clean.
 
 2. Test as you feel the urge using the plugins and features.

--- a/tools/prepare_release.sh
+++ b/tools/prepare_release.sh
@@ -1,68 +1,69 @@
 #!/bin/bash -eu
 
-[ "$#" -ne "2" ] && echo "usage: $0 <new version> <release branch name>" && exit 1
+if [[ "${GITHUB_REF}" != refs/tags/* ]]; then
+    echo "${GITHUB_REF} is not a tag!"
+    exit 1
+fi
+
+
 
 # stop on first error
 set -eu
 
-# configure git
-git config --global user.email "travis@travis-ci.org"
-git config --global user.name "Travis CI"
+RELEASE_TAG=${GITHUB_REF##refs/tags/}
+RELEASE_BRANCH=master
 
-# setup origin
-git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+echo "Preparing release ${RELEASE_TAG} on branch ${RELEASE_BRANCH}"
+
+# configure git
+git config --local user.name "m2e-code-quality-bot"
+git config --local user.email "m2e-code-quality-bot@users.noreply.github.com"
 
 # verify same commit as branch
 HEAD=$(git rev-parse --verify HEAD)
-export GITHUB_BRANCH=$(git ls-remote -q --refs | grep $HEAD | awk '{print $2}' | sed -e 's/^refs\/heads\///')
+GITHUB_BRANCH=$(git ls-remote -q --refs | grep "$HEAD" | awk '{print $2}' | sed -e 's/^refs\/heads\///')
 
-C=$(echo $GITHUB_BRANCH | wc -w)
+C=$(echo "$GITHUB_BRANCH" | wc -w)
 if [ "$C" -ne "1" ]; then echo "Tag cannot be resolved to branch name" && exit 1; fi
+if [ "$GITHUB_BRANCH" != "develop" ]; then echo "Tag is not on branch develop" && exit 1; fi
 
 # make sure no stale stuff before checkout
 git reset --hard
 
 # checkout release branch
-echo "checkout $2"
-git fetch origin > /dev/null 2>&1
-git checkout -B $2 origin/$2
+echo "checkout ${RELEASE_BRANCH}"
+git config --local remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+git fetch --unshallow origin
+git checkout -B "${RELEASE_BRANCH}" "origin/${RELEASE_BRANCH}"
 
 # merge develop into release
-git merge --no-ff -X theirs origin/$GITHUB_BRANCH
+NEW_VERSION="${RELEASE_TAG}.$(date +%Y%m%d%H%M)-r"
+git merge --no-ff -X theirs --message "Release ${NEW_VERSION} [skip ci]" "origin/${GITHUB_BRANCH}"
 
 # set version and add all changed POMs and add them to the merge commit
-echo "changing version to $1"
-mvn org.eclipse.tycho:tycho-versions-plugin:set-version -DnewVersion=$1 -Dtycho.mode=maven
-
-# Install github_changelog_generator
-gem install github_changelog_generator
+echo "changing version to ${NEW_VERSION}"
+./mvnw org.eclipse.tycho:tycho-versions-plugin:set-version -DnewVersion="${NEW_VERSION}" -Dtycho.mode=maven
 
 # Generate and add CHANGELOG.md
 echo "Generating CHANGELOG"
-github_changelog_generator -t ${GITHUB_TOKEN} --since-tag 0.12.0.201101081422
+bundle exec github_changelog_generator \
+    -t "${GITHUB_TOKEN}" \
+    --since-tag 0.12.0.201101081422 \
+    --no-verbose
 git add CHANGELOG.md
 
 # commit changes to branch (will be pushed after release)
-git commit -a --amend --message "Release $1 [skip ci]" > /dev/null 2>&1
-
-# Get latest (soon to be previous) release
-previous_release_tag=$(curl -s \
-    https://${GITHUB_TOKEN}@api.github.com/repos/${TRAVIS_REPO_SLUG}/releases/latest | \
-        jq -r .tag_name)
-
-# Create release notes
-github_changelog_generator -t ${GITHUB_TOKEN} --no-unreleased --output /tmp/CHANGELOG-$1.md --since-tag ${previous_release_tag}
-export RELEASE_CHANGELOG=$(< /tmp/CHANGELOG-$1.md)
+git commit -a --amend --no-edit
 
 # move tag to release branch
-git tag -a -f $TRAVIS_TAG -m "Release $TRAVIS_TAG"
+git tag -a -f "$RELEASE_TAG" -m "Release $RELEASE_TAG"
 
 # checkout original branch
-echo "checkout $GITHUB_BRANCH"
-git checkout -B $GITHUB_BRANCH
+echo "checkout ${GITHUB_BRANCH}"
+git checkout -B "${GITHUB_BRANCH}" "origin/${GITHUB_BRANCH}"
 
 # merge back release branch to develop
-git merge $2
+git merge "${RELEASE_BRANCH}"
 
 # reset options
 set +eu

--- a/tools/publish-update-site.sh
+++ b/tools/publish-update-site.sh
@@ -108,18 +108,12 @@ if [ -n "$RELEASE_TAG" ]; then
     END_LINE=$((END_LINE - 1))
     head -$END_LINE CHANGELOG.md > "${CURRENT_SITE_FOLDER}/${RELEASE_TAG}/CHANGELOG.md"
 else
-    # get current version
-    current_version=$(./mvnw --batch-mode --no-transfer-progress \
-            org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
-            -Dexpression=project.version -q -DforceStdout \
-            -Dtycho.mode=maven)
-
     # Create release notes (snapshot)
     bundle exec github_changelog_generator \
         -t "${GITHUB_TOKEN}" \
         --output "${CURRENT_SITE_FOLDER}/snapshot/CHANGELOG.md" \
         --unreleased-only \
-        --unreleased-label "${current_version} ($(date +%Y-%m-%d))" \
+        --future-release "develop" \
         --no-verbose
 fi
 

--- a/tools/publish-update-site.sh
+++ b/tools/publish-update-site.sh
@@ -1,5 +1,13 @@
 #!/bin/bash -eu
 
+if [[ "${GITHUB_REF}" != refs/tags/* || "${GITHUB_REF}" != refs/heads/develop ]]; then
+    echo "${GITHUB_REF} is neither develop branch nor a tag!"
+    exit 1
+fi
+
+# stop on first error
+set -eu
+
 #
 # This script requires the env var "GITHUB_TOKEN". It uses this token to commit
 # to https://github.com/m2e-code-quality/m2e-code-quality-p2-site and
@@ -13,11 +21,14 @@
 GIT_ROOT_DIR="$(cd "$(dirname "$0")" && git rev-parse --show-toplevel)"
 OLD_RELEASES_FILE=${GIT_ROOT_DIR}/tools/old_releases.list
 
-TRAVIS_TAG=""
+RELEASE_TAG=""
+if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+    RELEASE_TAG=${GITHUB_REF##refs/tags/}
+fi
 CURRENT_SITE_FOLDER=current-site
 SITE_GITHUB_BRANCH=gh-pages
 SITE_GITHUB_REPO=m2e-code-quality/m2e-code-quality-p2-site
-SITE_GITHUB_REPO_URL="https://${GITHUB_TOKEN}@github.com/${SITE_GITHUB_REPO}"
+SITE_GITHUB_REPO_URL="https://github.com/${SITE_GITHUB_REPO}"
 
 NEW_SITE_FOLDER=com.basistech.m2e.code.quality.site/target/repository/
 
@@ -66,17 +77,18 @@ rm -rf "${CURRENT_SITE_FOLDER}"
 mkdir "${CURRENT_SITE_FOLDER}"
 pushd "${CURRENT_SITE_FOLDER}"
 git init -q --initial-branch="${SITE_GITHUB_BRANCH}"
-git config user.name "m2e-code-quality-bot"
-git config user.email "m2e-code-quality-bot@users.noreply.github.com"
+git config --local user.name "m2e-code-quality-bot"
+git config --local user.email "m2e-code-quality-bot@users.noreply.github.com"
+git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n "x-access-token:${GITHUB_TOKEN}"|base64)"
 git remote add origin "${SITE_GITHUB_REPO_URL}"
 git pull --rebase origin "${SITE_GITHUB_BRANCH}"
 popd
 
 ## -- integrate (copy) new version to the site
-if [ -n "$TRAVIS_TAG" ]; then
-  rm -rf "${CURRENT_SITE_FOLDER:?}/${TRAVIS_TAG}" \
-    && mkdir "${CURRENT_SITE_FOLDER}/${TRAVIS_TAG}" \
-    && cp -R "${NEW_SITE_FOLDER}"/* "${CURRENT_SITE_FOLDER}/${TRAVIS_TAG}/"
+if [ -n "$RELEASE_TAG" ]; then
+  rm -rf "${CURRENT_SITE_FOLDER:?}/${RELEASE_TAG}" \
+    && mkdir "${CURRENT_SITE_FOLDER}/${RELEASE_TAG}" \
+    && cp -R "${NEW_SITE_FOLDER}"/* "${CURRENT_SITE_FOLDER}/${RELEASE_TAG}/"
 else
   rm -rf "${CURRENT_SITE_FOLDER:?}/snapshot" \
     && mkdir "${CURRENT_SITE_FOLDER}/snapshot" \
@@ -89,19 +101,26 @@ STABLE_RELEASES="$(cat "${OLD_RELEASES_FILE}") $(find ${CURRENT_SITE_FOLDER}/* -
 regenCompositeMetadata "${STABLE_RELEASES}" "${CURRENT_SITE_FOLDER}/"
 
 ## -- generate changelog
-# get current version
-current_version=$(./mvnw --batch-mode --no-transfer-progress \
-        org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
-        -Dexpression=project.version -q -DforceStdout \
-        -Dtycho.mode=maven)
+if [ -n "$RELEASE_TAG" ]; then
+    # extract the release notes
+    END_LINE=$(grep -n "^## " CHANGELOG.md|head -2|tail -1|cut -d ":" -f 1)
+    END_LINE=$((END_LINE - 1))
+    head -$END_LINE CHANGELOG.md > "${CURRENT_SITE_FOLDER}/${RELEASE_TAG}/CHANGELOG.md"
+else
+    # get current version
+    current_version=$(./mvnw --batch-mode --no-transfer-progress \
+            org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
+            -Dexpression=project.version -q -DforceStdout \
+            -Dtycho.mode=maven)
 
-# Create release notes (snapshot)
-bundle exec github_changelog_generator \
-    -t "${GITHUB_TOKEN}" \
-    --output "${CURRENT_SITE_FOLDER}/snapshot/CHANGELOG.md" \
-    --unreleased-only \
-    --unreleased-label "${current_version} ($(date +%Y-%m-%d))"
-
+    # Create release notes (snapshot)
+    bundle exec github_changelog_generator \
+        -t "${GITHUB_TOKEN}" \
+        --output "${CURRENT_SITE_FOLDER}/snapshot/CHANGELOG.md" \
+        --unreleased-only \
+        --unreleased-label "${current_version} ($(date +%Y-%m-%d))" \
+        --no-verbose
+fi
 
 # create a new single commit
 pushd "${CURRENT_SITE_FOLDER}"

--- a/tools/publish-update-site.sh
+++ b/tools/publish-update-site.sh
@@ -9,12 +9,13 @@ fi
 set -eu
 
 #
-# This script requires the env var "GITHUB_TOKEN". It uses this token to commit
-# to https://github.com/m2e-code-quality/m2e-code-quality-p2-site and
-# fetch information to generate a changelog.
+# This script requires two tokens as env vars:
+# * PUBLISH_SITE_TOKEN: This token is used to commit
+#   to https://github.com/m2e-code-quality/m2e-code-quality-p2-site
+#   Since this script is called from a workflow from repo m2e-code-quality, the default
+#   GITHUB_TOKEN won't work to commit to a different repo (m2e-code-quality-p2-site).
 #
-# Since this script is called from a workflow from repo m2e-code-quality, the default
-# GITHUB_TOKEN won't work to commit to a different repo (m2e-code-quality-p2-site).
+# * GITHUB_TOKEN: Is used to fetch information to generate a changelog.
 #
 
 
@@ -79,7 +80,7 @@ pushd "${CURRENT_SITE_FOLDER}"
 git init -q --initial-branch="${SITE_GITHUB_BRANCH}"
 git config --local user.name "m2e-code-quality-bot"
 git config --local user.email "m2e-code-quality-bot@users.noreply.github.com"
-git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n "x-access-token:${GITHUB_TOKEN}"|base64)"
+git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n "x-access-token:${PUBLISH_SITE_TOKEN}"|base64)"
 git remote add origin "${SITE_GITHUB_REPO_URL}"
 git pull --rebase origin "${SITE_GITHUB_BRANCH}"
 popd
@@ -128,5 +129,6 @@ git checkout --orphan=gh-pages-2
 git add -A
 git commit -a -m "Update ${SITE_GITHUB_REPO}"
 git push --force origin "gh-pages-2:${SITE_GITHUB_BRANCH}"
+git config --local --unset-all http.https://github.com/.extraheader
 popd
 


### PR DESCRIPTION
This PR adjusts the scripts to run on github actions.
The release procedure is the same as before - create and push a tag from the branch `develop`.
