### PR TITLE
Improve build to test multiple target platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ on:
 jobs:
   # verify build on one node before multiple builds on different os are started
   fail-fast-build:
+    name: fail-fast verify (ubuntu-latest, oxygen)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -56,6 +57,7 @@ jobs:
 
   verify:
     needs: fail-fast-build
+    name: verify (${{ matrix.os }}, ${{ matrix.target }})
 
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,26 +20,12 @@ on:
       - '!gh-pages'
 
 jobs:
-  build:
-
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, windows-latest, macOS-latest ]
-      fail-fast: false
-
-    runs-on: ${{ matrix.os }}
-
-    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
-
+  # verify build on one node before multiple builds on different os are started
+  fail-fast-build:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - uses: ruby/setup-ruby@v1
-        if: ${{ runner.os == 'Linux' }}
-        with:
-          ruby-version: 2.7
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Set up JDK 8
         id: java8
@@ -63,8 +49,144 @@ jobs:
           echo "JAVA11_HOME=${{ steps.java11.outputs.path }}" >> $GITHUB_ENV
           cp tools/toolchains.xml $HOME/.m2/
 
+      - name: Build with Maven
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: bash tools/build.sh -Dtarget.platform=oxygen
+
+  verify:
+    needs: fail-fast-build
+
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macOS-latest ]
+        target: [ oxygen, 2022-06 ]
+        exclude:
+          # exclude the fail-fast-build, which already run
+          - os: ubuntu-latest
+            target: oxygen
+      fail-fast: true
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 8
+        id: java8
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: '8'
+
+      - name: Set up JDK 11
+        id: java11
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: 'maven'
+
+      - name: Setup maven toolchains.xml
+        shell: bash
+        run: |
+          echo "JAVA8_HOME=${{ steps.java8.outputs.path }}" >> $GITHUB_ENV
+          echo "JAVA11_HOME=${{ steps.java11.outputs.path }}" >> $GITHUB_ENV
+          cp tools/toolchains.xml $HOME/.m2/
+
+      - name: Build with Maven
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: bash tools/build.sh -Dtarget.platform=${{ matrix.target }}
+
+  publish-snapshot-update-site:
+    needs: verify
+    if: ${{ github.event_name == 'push' && github.repository == 'm2e-code-quality/m2e-code-quality' && github.ref == 'refs/heads/develop' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 8
+        id: java8
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: '8'
+
+      - name: Set up JDK 11
+        id: java11
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: 'maven'
+
+      - name: Setup maven toolchains.xml
+        shell: bash
+        run: |
+          echo "JAVA8_HOME=${{ steps.java8.outputs.path }}" >> $GITHUB_ENV
+          echo "JAVA11_HOME=${{ steps.java11.outputs.path }}" >> $GITHUB_ENV
+          cp tools/toolchains.xml $HOME/.m2/
+
+      - name: Build with Maven
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: bash tools/build.sh -Dtarget.platform=oxygen -Dmaven.test.skip=true
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - name: Publish update site
+        shell: bash
+        run: tools/publish-update-site.sh
+        env:
+          SITE_DEPLOY_PRIVATE_KEY: ${{ secrets.SITE_DEPLOY_PRIVATE_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    needs: verify
+    if: ${{ github.event_name == 'push' && github.repository == 'm2e-code-quality/m2e-code-quality' && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 8
+        id: java8
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: '8'
+
+      - name: Set up JDK 11
+        id: java11
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: 'maven'
+
+      - name: Setup maven toolchains.xml
+        shell: bash
+        run: |
+          echo "JAVA8_HOME=${{ steps.java8.outputs.path }}" >> $GITHUB_ENV
+          echo "JAVA11_HOME=${{ steps.java11.outputs.path }}" >> $GITHUB_ENV
+          cp tools/toolchains.xml $HOME/.m2/
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
       - name: Prepare release
-        if: ${{ runner.os == 'Linux' && github.event_name == 'push' && github.repository == 'm2e-code-quality/m2e-code-quality' && startsWith(github.ref, 'refs/tags/') }}
         shell: bash
         run: tools/prepare_release.sh
         env:
@@ -73,12 +195,11 @@ jobs:
       - name: Build with Maven
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: bash tools/build.sh
+          run: bash tools/build.sh -Dtarget.platform=oxygen -Dmaven.test.skip=true
         env:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
 
       - name: Publish update site
-        if: ${{ runner.os == 'Linux' && github.event_name == 'push' && github.repository == 'm2e-code-quality/m2e-code-quality' }}
         shell: bash
         run: tools/publish-update-site.sh
         env:
@@ -86,7 +207,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish release
-        if: ${{ runner.os == 'Linux' && github.event_name == 'push' && github.repository == 'm2e-code-quality/m2e-code-quality' && startsWith(github.ref, 'refs/tags/') }}
         shell: bash
         run: tools/release.sh
         env:

--- a/com.basistech.m2e.code.quality.target-platform/2022-06.target
+++ b/com.basistech.m2e.code.quality.target-platform/2022-06.target
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="Eclipse 4.24.x (2022-06)">
+    <locations>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="org.eclipse.platform.ide" version="4.24.0.I20220607-0700"/>
+            <unit id="org.eclipse.jdt.feature.group" version="3.18.1200.v20220607-0700"/>
+            <unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.20.1.20220227-1319"/>
+            <unit id="org.eclipse.m2e.feature.feature.group" version="1.20.1.20220227-1319"/>
+            <unit id="org.apache.commons.lang" version="2.6.0.v20220406-2305"/>"
+            <repository location="https://download.eclipse.org/releases/2022-06/"/>
+         </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="net.sf.eclipsecs.feature.group" version="0.0.0"/>
+            <repository location="https://checkstyle.org/eclipse-cs-update-site/"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="net.sourceforge.pmd.eclipse.feature.group" version="0.0.0"/>
+            <repository location="https://pmd.github.io/pmd-eclipse-plugin-p2-site/"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="0.0.0"/>
+            <repository location="https://findbugs.cs.umd.edu/eclipse/"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="com.github.spotbugs.plugin.eclipse.feature.group" version="0.0.0"/>
+           <repository location="https://spotbugs.github.io/eclipse/"/>
+        </location>
+    </locations>
+    <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+</target>

--- a/com.basistech.m2e.code.quality.target-platform/oxygen.target
+++ b/com.basistech.m2e.code.quality.target-platform/oxygen.target
@@ -12,7 +12,7 @@
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="net.sf.eclipsecs.feature.group" version="0.0.0"/>
-            <repository location="https://checkstyle.org/eclipse-cs-update-site/"/>
+            <repository location="https://checkstyle.org/eclipse-cs-update-site/updates/9.x"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="net.sourceforge.pmd.eclipse.feature.group" version="0.0.0"/>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <target.platform>oxygen</target.platform>
+        <target.ee>Java-1.8</target.ee>
 
         <tycho-version>2.7.1</tycho-version>
         <main.basedir>${basedir}</main.basedir>
@@ -93,7 +94,7 @@
                 <configuration>
                     <toolchains>
                         <jdk>
-                            <id>JavaSE-1.8</id>
+                            <id>${target.ee}</id>
                         </jdk>
                     </toolchains>
                 </configuration>
@@ -287,6 +288,7 @@
             </build>
         </profile>
         <profile>
+            <id>2021-09</id>
             <activation>
                 <property>
                     <name>target.platform</name>
@@ -294,30 +296,22 @@
                 </property>
             </activation>
             <properties>
-                <java.version>11</java.version>
+                <maven.compiler.release>11</maven.compiler.release>
+                <target.ee>JavaSE-11</target.ee>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.eclipse.tycho</groupId>
-                        <artifactId>tycho-compiler-plugin</artifactId>
-                        <configuration>
-                            <release>11</release>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-toolchains-plugin</artifactId>
-                        <configuration>
-                            <toolchains>
-                                <jdk>
-                                    <id>JavaSE-11</id>
-                                </jdk>
-                            </toolchains>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
+        </profile>
+        <profile>
+            <id>2022-06</id>
+            <activation>
+                <property>
+                    <name>target.platform</name>
+                    <value>2022-06</value>
+                </property>
+            </activation>
+            <properties>
+                <maven.compiler.release>11</maven.compiler.release>
+                <target.ee>JavaSE-11</target.ee>
+            </properties>
         </profile>
         <profile>
             <id>local-findbugs-p2</id>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <target.platform>oxygen</target.platform>
-        <target.ee>Java-1.8</target.ee>
+        <target.ee>JavaSE-1.8</target.ee>
 
         <tycho-version>2.7.1</tycho-version>
         <main.basedir>${basedir}</main.basedir>

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -21,9 +21,11 @@ if [[ "${RUNNER_OS}" == "Linux"
                      )
 fi
 
+additional_options=("$@")
+
 # make org.jboss.tools.tycho-plugins:repository-utils happy:
 # for pull requests it sees a ref "refs/remotes/pull/<PR-Number>/merge"
 # but no remote named "pull" exists...
 git remote add pull https://github.com/m2e-code-quality/m2e-code-quality
 
-./mvnw clean verify -e -B -V -ntp "${signing_options[@]}"
+./mvnw clean verify -e -B -V -ntp "${signing_options[@]}" "${additional_options[@]}"


### PR DESCRIPTION
This contains a fix, so that the oxygen target (the default target platform) works again: Eclipse Checkstyle Plugin 10 requires now at least eclipse 2019-06, which requires at least java 11 (https://checkstyle.org/eclipse-cs/#!/releasenotes)
