### PR TITLE
Set version to 2.0.0-SNAPSHOT

### DIFF
--- a/com.basistech.m2e.code.quality.checkstyle.feature/feature.xml
+++ b/com.basistech.m2e.code.quality.checkstyle.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.basistech.m2e.code.quality.checkstyle.feature"
       label="Checkstyle configuration plugin for M2Eclipse"
-      version="1.1.6.qualifier"
+      version="2.0.0.qualifier"
       plugin="com.basistech.m2e.code.quality.shared">
 
    <description>

--- a/com.basistech.m2e.code.quality.checkstyle.feature/pom.xml
+++ b/com.basistech.m2e.code.quality.checkstyle.feature/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.basistech.m2e-code-quality</groupId>
         <artifactId>m2e-code-quality-plugins</artifactId>
-        <version>1.1.6-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>com.basistech.m2e.code.quality.checkstyle.feature</artifactId>

--- a/com.basistech.m2e.code.quality.checkstyle.test/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.checkstyle.test/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2Eclipse Project Configurator for Eclipse Checkstyle Tests
 Bundle-SymbolicName: com.basistech.m2e.code.quality.checkstyle.test
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-Vendor: Basis Technology Corp.
-Fragment-Host: com.basistech.m2e.code.quality.checkstyle;bundle-version="[1.1.6,2.0.0)"
+Fragment-Host: com.basistech.m2e.code.quality.checkstyle;bundle-version="2.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit,
- com.basistech.m2e.code.quality.shared.test;bundle-version="1.1.6",
+ com.basistech.m2e.code.quality.shared.test;bundle-version="2.0.0",
  org.eclipse.m2e.tests.common
 Automatic-Module-Name: com.basistech.m2e.code.quality.checkstyle.test

--- a/com.basistech.m2e.code.quality.checkstyle.test/pom.xml
+++ b/com.basistech.m2e.code.quality.checkstyle.test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.basistech.m2e-code-quality</groupId>
         <artifactId>m2e-code-quality-plugins</artifactId>
-        <version>1.1.6-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>com.basistech.m2e.code.quality.checkstyle.test</artifactId>

--- a/com.basistech.m2e.code.quality.checkstyle/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.checkstyle/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: M2Eclipse Project Configurator for Eclipse Checkstyle
 Bundle-SymbolicName: com.basistech.m2e.code.quality.checkstyle
  ;singleton:=true
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 2.0.0.qualifier
 Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.m2e.core;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,2.0.0)",
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.core.runtime;bundle-version="3.6.0",
  net.sf.eclipsecs.core;bundle-version="5.2.0",
  net.sf.eclipsecs.checkstyle;bundle-version="5.2.0",
- com.basistech.m2e.code.quality.shared;bundle-version="1.1.6",
+ com.basistech.m2e.code.quality.shared;bundle-version="2.0.0",
  org.apache.commons.lang;bundle-version="2.6.0",
  org.slf4j.api;bundle-version="1.6.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/com.basistech.m2e.code.quality.checkstyle/pom.xml
+++ b/com.basistech.m2e.code.quality.checkstyle/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.basistech.m2e-code-quality</groupId>
         <artifactId>m2e-code-quality-plugins</artifactId>
-        <version>1.1.6-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>com.basistech.m2e.code.quality.checkstyle</artifactId>

--- a/com.basistech.m2e.code.quality.findbugs.feature/feature.xml
+++ b/com.basistech.m2e.code.quality.findbugs.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.basistech.m2e.code.quality.findbugs.feature"
       label="FindBugs configuration plugin for M2Eclipse"
-      version="1.1.6.qualifier"
+      version="2.0.0.qualifier"
       plugin="com.basistech.m2e.code.quality.shared">
 
    <description>

--- a/com.basistech.m2e.code.quality.findbugs.feature/pom.xml
+++ b/com.basistech.m2e.code.quality.findbugs.feature/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.basistech.m2e-code-quality</groupId>
         <artifactId>m2e-code-quality-plugins</artifactId>
-        <version>1.1.6-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>com.basistech.m2e.code.quality.findbugs.feature</artifactId>

--- a/com.basistech.m2e.code.quality.findbugs.test/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.findbugs.test/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2Eclipse Project Configurator for Eclipse FindBugs Tests
 Bundle-SymbolicName: com.basistech.m2e.code.quality.findbugs.test
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-Vendor: Basis Technology Corp.
-Fragment-Host: com.basistech.m2e.code.quality.findbugs;bundle-version="[1.1.6,2.0.0)"
+Fragment-Host: com.basistech.m2e.code.quality.findbugs;bundle-version="2.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit,
- com.basistech.m2e.code.quality.shared.test;bundle-version="1.1.6",
+ com.basistech.m2e.code.quality.shared.test;bundle-version="2.0.0",
  org.eclipse.m2e.tests.common
 Automatic-Module-Name: com.basistech.m2e.code.quality.findbugs.test

--- a/com.basistech.m2e.code.quality.findbugs.test/pom.xml
+++ b/com.basistech.m2e.code.quality.findbugs.test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.basistech.m2e-code-quality</groupId>
         <artifactId>m2e-code-quality-plugins</artifactId>
-        <version>1.1.6-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>com.basistech.m2e.code.quality.findbugs.test</artifactId>

--- a/com.basistech.m2e.code.quality.findbugs/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.findbugs/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2Eclipse Project Configurator for Eclipse FindBugs
 Bundle-SymbolicName: com.basistech.m2e.code.quality.findbugs;singleton:=true
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 2.0.0.qualifier
 Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.m2e.core;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,2.0.0)",
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.ui.console,
  org.eclipse.jdt.core;bundle-version="3.6.0",
  org.eclipse.core.runtime;bundle-version="3.6.0",
- com.basistech.m2e.code.quality.shared;bundle-version="1.1.6",
+ com.basistech.m2e.code.quality.shared;bundle-version="2.0.0",
  org.eclipse.ui.workbench;bundle-version="3.6.0",
  org.eclipse.jface;bundle-version="3.6.0",
  edu.umd.cs.findbugs.plugin.eclipse;bundle-version="[2.0.0,4.0.0)",

--- a/com.basistech.m2e.code.quality.findbugs/pom.xml
+++ b/com.basistech.m2e.code.quality.findbugs/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.basistech.m2e-code-quality</groupId>
         <artifactId>m2e-code-quality-plugins</artifactId>
-        <version>1.1.6-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>com.basistech.m2e.code.quality.findbugs</artifactId>

--- a/com.basistech.m2e.code.quality.pmd.feature/feature.xml
+++ b/com.basistech.m2e.code.quality.pmd.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.basistech.m2e.code.quality.pmd.feature"
       label="PMD configuration plugin for M2Eclipse"
-      version="1.1.6.qualifier"
+      version="2.0.0.qualifier"
       plugin="com.basistech.m2e.code.quality.shared">
 
    <description>

--- a/com.basistech.m2e.code.quality.pmd.feature/pom.xml
+++ b/com.basistech.m2e.code.quality.pmd.feature/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.basistech.m2e-code-quality</groupId>
         <artifactId>m2e-code-quality-plugins</artifactId>
-        <version>1.1.6-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>com.basistech.m2e.code.quality.pmd.feature</artifactId>

--- a/com.basistech.m2e.code.quality.pmd.test/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.pmd.test/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2Eclipse Project Configurator for Eclipse PMD Tests
 Bundle-SymbolicName: com.basistech.m2e.code.quality.pmd.test
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-Vendor: Basis Technology Corp.
-Fragment-Host: com.basistech.m2e.code.quality.pmd;bundle-version="[1.1.6,2.0.0)"
+Fragment-Host: com.basistech.m2e.code.quality.pmd;bundle-version="2.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit,
- com.basistech.m2e.code.quality.shared.test;bundle-version="1.1.6",
+ com.basistech.m2e.code.quality.shared.test;bundle-version="2.0.0",
  org.eclipse.m2e.tests.common
 Automatic-Module-Name: com.basistech.m2e.code.quality.pmd.test

--- a/com.basistech.m2e.code.quality.pmd.test/pom.xml
+++ b/com.basistech.m2e.code.quality.pmd.test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.basistech.m2e-code-quality</groupId>
         <artifactId>m2e-code-quality-plugins</artifactId>
-        <version>1.1.6-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>com.basistech.m2e.code.quality.pmd.test</artifactId>

--- a/com.basistech.m2e.code.quality.pmd/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.pmd/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: M2Eclipse Extension to support Eclipse PMD Configuration
 Bundle-SymbolicName: com.basistech.m2e.code.quality.pmd
  ;singleton:=true
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 2.0.0.qualifier
 Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.m2e.core;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,2.0.0)",
@@ -12,7 +12,7 @@ Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.ui.console,
  org.eclipse.jdt.core;bundle-version="3.6.0",
  org.eclipse.core.runtime;bundle-version="3.6.0",
- com.basistech.m2e.code.quality.shared;bundle-version="1.1.6",
+ com.basistech.m2e.code.quality.shared;bundle-version="2.0.0",
  net.sourceforge.pmd.eclipse.plugin;bundle-version="[4.0.0,5.0.0)",
  org.slf4j.api;bundle-version="1.6.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/com.basistech.m2e.code.quality.pmd/pom.xml
+++ b/com.basistech.m2e.code.quality.pmd/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.basistech.m2e-code-quality</groupId>
         <artifactId>m2e-code-quality-plugins</artifactId>
-        <version>1.1.6-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>com.basistech.m2e.code.quality.pmd</artifactId>

--- a/com.basistech.m2e.code.quality.shared.test/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.shared.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2Eclipse Project Configurator for Eclipse Shared Tests
 Bundle-SymbolicName: com.basistech.m2e.code.quality.shared.test
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-Vendor: Basis Technology Corp.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,2.0.0)",

--- a/com.basistech.m2e.code.quality.shared.test/pom.xml
+++ b/com.basistech.m2e.code.quality.shared.test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.basistech.m2e-code-quality</groupId>
         <artifactId>m2e-code-quality-plugins</artifactId>
-        <version>1.1.6-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>com.basistech.m2e.code.quality.shared.test</artifactId>

--- a/com.basistech.m2e.code.quality.shared/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.shared/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Shared Code for M2 Code Quality Plugin Extensions
 Bundle-SymbolicName: com.basistech.m2e.code.quality.shared
  ;singleton:=true
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: BasisTech
 Export-Package: com.basistech.m2e.code.quality.shared,

--- a/com.basistech.m2e.code.quality.shared/pom.xml
+++ b/com.basistech.m2e.code.quality.shared/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.basistech.m2e-code-quality</groupId>
         <artifactId>m2e-code-quality-plugins</artifactId>
-        <version>1.1.6-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>com.basistech.m2e.code.quality.shared</artifactId>

--- a/com.basistech.m2e.code.quality.site/pom.xml
+++ b/com.basistech.m2e.code.quality.site/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.basistech.m2e-code-quality</groupId>
 		<artifactId>m2e-code-quality-plugins</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>com.basistech.m2e.code.quality.site</artifactId>

--- a/com.basistech.m2e.code.quality.spotbugs.feature/feature.xml
+++ b/com.basistech.m2e.code.quality.spotbugs.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.basistech.m2e.code.quality.spotbugs.feature"
       label="SpotBugs configuration plugin for M2Eclipse"
-      version="1.1.6.qualifier"
+      version="2.0.0.qualifier"
       plugin="com.basistech.m2e.code.quality.shared">
 
    <description>

--- a/com.basistech.m2e.code.quality.spotbugs.feature/pom.xml
+++ b/com.basistech.m2e.code.quality.spotbugs.feature/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.basistech.m2e-code-quality</groupId>
         <artifactId>m2e-code-quality-plugins</artifactId>
-        <version>1.1.6-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>com.basistech.m2e.code.quality.spotbugs.feature</artifactId>

--- a/com.basistech.m2e.code.quality.spotbugs.test/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.spotbugs.test/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2Eclipse Project Configurator for Eclipse SpotBugs Tests
 Bundle-SymbolicName: com.basistech.m2e.code.quality.spotbugs.test
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-Vendor: Basis Technology Corp.
-Fragment-Host: com.basistech.m2e.code.quality.spotbugs;bundle-version="[1.1.6,2.0.0)"
+Fragment-Host: com.basistech.m2e.code.quality.spotbugs;bundle-version="2.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit,
- com.basistech.m2e.code.quality.shared.test;bundle-version="1.1.6",
+ com.basistech.m2e.code.quality.shared.test;bundle-version="2.0.0",
  org.eclipse.m2e.tests.common
 Automatic-Module-Name: com.basistech.m2e.code.quality.spotbugs.test

--- a/com.basistech.m2e.code.quality.spotbugs.test/pom.xml
+++ b/com.basistech.m2e.code.quality.spotbugs.test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.basistech.m2e-code-quality</groupId>
         <artifactId>m2e-code-quality-plugins</artifactId>
-        <version>1.1.6-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>com.basistech.m2e.code.quality.spotbugs.test</artifactId>

--- a/com.basistech.m2e.code.quality.spotbugs/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.spotbugs/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2Eclipse Project Configurator for Eclipse SpotBugs
 Bundle-SymbolicName: com.basistech.m2e.code.quality.spotbugs;singleton:=true
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 2.0.0.qualifier
 Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.m2e.core;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,2.0.0)",
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.m2e.jdt;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.ui.console,
  org.eclipse.jdt.core;bundle-version="3.6.0",
  org.eclipse.core.runtime;bundle-version="3.6.0",
- com.basistech.m2e.code.quality.shared;bundle-version="1.1.6",
+ com.basistech.m2e.code.quality.shared;bundle-version="2.0.0",
  org.eclipse.ui.workbench;bundle-version="3.6.0",
  org.eclipse.jface;bundle-version="3.6.0",
  com.github.spotbugs.plugin.eclipse,

--- a/com.basistech.m2e.code.quality.spotbugs/pom.xml
+++ b/com.basistech.m2e.code.quality.spotbugs/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.basistech.m2e-code-quality</groupId>
         <artifactId>m2e-code-quality-plugins</artifactId>
-        <version>1.1.6-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>com.basistech.m2e.code.quality.spotbugs</artifactId>

--- a/com.basistech.m2e.code.quality.target-platform/pom.xml
+++ b/com.basistech.m2e.code.quality.target-platform/pom.xml
@@ -8,7 +8,7 @@
  <parent>
   <groupId>com.basistech.m2e-code-quality</groupId>
   <artifactId>m2e-code-quality-plugins</artifactId>
-  <version>1.1.6-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
  </parent>
 
  <artifactId>com.basistech.m2e.code.quality.target-platform</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.basistech.m2e-code-quality</groupId>
     <artifactId>m2e-code-quality-plugins</artifactId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <scm>


### PR DESCRIPTION
The version change is necessary, since upgrading to m2e 2.0.4 is a incompatible update.

The upcoming 2.0.0 release of m2e-code-quality will only work with Eclipse 4.25 (2022-09) or later.

* Refs #292 
* Refs #294 