### PR TITLE
[ci] Refactor Github Actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,31 @@
+name: 'Setup'
+description: 'Setup java, maven and toolchains and optionally ruby'
+inputs:
+  withRuby:
+    description: 'Setup ruby as well'
+    required: false
+    default: 'false'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Ruby
+      if: ${{ inputs.withRuby == 'true' }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+    - name: Set up JDK 17
+      id: java17
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: '17'
+        cache: 'maven'
+
+    - name: Setup maven toolchains.xml
+      shell: bash
+      run: |
+        echo "JAVA17_HOME=${{ steps.java17.outputs.path }}" >> $GITHUB_ENV
+        cp tools/toolchains.xml $HOME/.m2/

--- a/.github/actions/verify/action.yml
+++ b/.github/actions/verify/action.yml
@@ -1,0 +1,28 @@
+#
+# Reusable action to build and verify m2e-code-quality plugins
+#
+
+name: 'Verify'
+description: 'Executes the maven build'
+inputs:
+  targetPlatform:
+    description: 'The eclipse target platform to build the plugins against'
+    required: true
+  skipTests:
+    description: 'Whether to skip building and executing the unit tests'
+    required: false
+    default: 'false'
+  keystorePassword:
+    description: 'Password for the keystore in order to sign the plugins'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Build with Maven
+      uses: GabrielBB/xvfb-action@v1
+      with:
+        run: bash tools/build.sh -Dtarget.platform=${{ inputs.targetPlatform }} -Dmaven.test.skip=${{ inputs.skipTests }}
+      env:
+        KEYSTORE_PASSWORD: ${{ inputs.keystorePassword }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,150 +24,62 @@ jobs:
   fail-fast-build:
     name: fail-fast verify (ubuntu-latest, 2022-09)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Set up JDK 8
-        id: java8
-        uses: actions/setup-java@v2
+      - uses: ./.github/actions/setup
+
+      - uses: ./.github/actions/verify
         with:
-          distribution: temurin
-          java-version: '8'
-
-      - name: Set up JDK 11
-        id: java11
-        uses: actions/setup-java@v2
-        with:
-          distribution: temurin
-          java-version: '11'
-
-      - name: Set up JDK 17
-        id: java17
-        uses: actions/setup-java@v2
-        with:
-          distribution: temurin
-          java-version: '17'
-          cache: 'maven'
-
-      - name: Setup maven toolchains.xml
-        shell: bash
-        run: |
-          echo "JAVA8_HOME=${{ steps.java8.outputs.path }}" >> $GITHUB_ENV
-          echo "JAVA11_HOME=${{ steps.java11.outputs.path }}" >> $GITHUB_ENV
-          echo "JAVA17_HOME=${{ steps.java17.outputs.path }}" >> $GITHUB_ENV
-          cp tools/toolchains.xml $HOME/.m2/
-
-      - name: Build with Maven
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: bash tools/build.sh -Dtarget.platform=2022-09
+          targetPlatform: 2022-09
 
   verify:
     needs: fail-fast-build
-    name: verify (${{ matrix.os }}, ${{ matrix.target }})
+    name: verify (${{ matrix.os }}, ${{ matrix.targetPlatform }})
+    timeout-minutes: 60
 
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        target: [ 2022-09 ]
+        targetPlatform: [ 2022-09 ]
         exclude:
-          # exclude the fail-fast-build, which already run
+          # exclude the fail-fast-build, which already ran
           - os: ubuntu-latest
-            target: 2022-09
+            targetPlatform: 2022-09
       fail-fast: true
 
     runs-on: ${{ matrix.os }}
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Set up JDK 8
-        id: java8
-        uses: actions/setup-java@v2
+      - uses: ./.github/actions/setup
+
+      - uses: ./.github/actions/verify
         with:
-          distribution: temurin
-          java-version: '8'
-
-      - name: Set up JDK 11
-        id: java11
-        uses: actions/setup-java@v2
-        with:
-          distribution: temurin
-          java-version: '11'
-
-      - name: Set up JDK 17
-        id: java17
-        uses: actions/setup-java@v2
-        with:
-          distribution: temurin
-          java-version: '17'
-          cache: 'maven'
-
-      - name: Setup maven toolchains.xml
-        shell: bash
-        run: |
-          echo "JAVA8_HOME=${{ steps.java8.outputs.path }}" >> $GITHUB_ENV
-          echo "JAVA11_HOME=${{ steps.java11.outputs.path }}" >> $GITHUB_ENV
-          echo "JAVA17_HOME=${{ steps.java17.outputs.path }}" >> $GITHUB_ENV
-          cp tools/toolchains.xml $HOME/.m2/
-
-      - name: Build with Maven
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: bash tools/build.sh -Dtarget.platform=${{ matrix.target }}
+          targetPlatform: ${{ matrix.targetPlatform }}
 
   publish-snapshot-update-site:
     needs: verify
     if: ${{ github.event_name == 'push' && github.repository == 'm2e-code-quality/m2e-code-quality' && github.ref == 'refs/heads/develop' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Set up JDK 8
-        id: java8
-        uses: actions/setup-java@v2
+      - uses: ./.github/actions/setup
         with:
-          distribution: temurin
-          java-version: '8'
+          withRuby: 'true'
 
-      - name: Set up JDK 11
-        id: java11
-        uses: actions/setup-java@v2
+      - uses: ./.github/actions/verify
         with:
-          distribution: temurin
-          java-version: '11'
-
-      - name: Set up JDK 17
-        id: java17
-        uses: actions/setup-java@v2
-        with:
-          distribution: temurin
-          java-version: '17'
-          cache: 'maven'
-
-      - name: Setup maven toolchains.xml
-        shell: bash
-        run: |
-          echo "JAVA8_HOME=${{ steps.java8.outputs.path }}" >> $GITHUB_ENV
-          echo "JAVA11_HOME=${{ steps.java11.outputs.path }}" >> $GITHUB_ENV
-          echo "JAVA17_HOME=${{ steps.java17.outputs.path }}" >> $GITHUB_ENV
-          cp tools/toolchains.xml $HOME/.m2/
-
-      - name: Build with Maven
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: bash tools/build.sh -Dtarget.platform=2022-09 -Dmaven.test.skip=true
-        env:
-          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          targetPlatform: 2022-09
+          keystorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
+          skipTests: 'true'
 
       - name: Publish update site
         shell: bash
@@ -180,45 +92,15 @@ jobs:
     needs: verify
     if: ${{ github.event_name == 'push' && github.repository == 'm2e-code-quality/m2e-code-quality' && startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Set up JDK 8
-        id: java8
-        uses: actions/setup-java@v2
+      - uses: ./.github/actions/setup
         with:
-          distribution: temurin
-          java-version: '8'
-
-      - name: Set up JDK 11
-        id: java11
-        uses: actions/setup-java@v2
-        with:
-          distribution: temurin
-          java-version: '11'
-
-      - name: Set up JDK 17
-        id: java17
-        uses: actions/setup-java@v2
-        with:
-          distribution: temurin
-          java-version: '17'
-          cache: 'maven'
-
-      - name: Setup maven toolchains.xml
-        shell: bash
-        run: |
-          echo "JAVA8_HOME=${{ steps.java8.outputs.path }}" >> $GITHUB_ENV
-          echo "JAVA11_HOME=${{ steps.java11.outputs.path }}" >> $GITHUB_ENV
-          echo "JAVA17_HOME=${{ steps.java17.outputs.path }}" >> $GITHUB_ENV
-          cp tools/toolchains.xml $HOME/.m2/
-
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          withRuby: 'true'
 
       - name: Prepare release
         shell: bash
@@ -226,12 +108,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build with Maven
-        uses: GabrielBB/xvfb-action@v1
+      - uses: ./.github/actions/verify
         with:
-          run: bash tools/build.sh -Dtarget.platform=2022-09 -Dmaven.test.skip=true
-        env:
-          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          targetPlatform: 2022-09
+          keystorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
+          skipTests: 'true'
 
       - name: Publish update site
         shell: bash

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The latest release can be installed from the Eclipse Update Site at
 
 **Building**
 
-The project uses maven and tycho. You need a Java8 JDK and a Java11 JDK and setup
+The project uses maven and tycho. You need at least a Java17 JDK and setup
 [Maven Toolchains](https://maven.apache.org/guides/mini/guide-using-toolchains.html) correctly.
 You can use the project's [toolchains.xml](tools/toolchains.xml) as a template.
 

--- a/tools/toolchains.xml
+++ b/tools/toolchains.xml
@@ -6,28 +6,6 @@
     <toolchain>
         <type>jdk</type>
         <provides>
-            <version>1.8</version>
-            <vendor>openjdk</vendor>
-            <id>JavaSE-1.8</id>
-        </provides>
-        <configuration>
-            <jdkHome>${env.JAVA8_HOME}</jdkHome>
-        </configuration>
-    </toolchain>
-    <toolchain>
-        <type>jdk</type>
-        <provides>
-            <version>11</version>
-            <vendor>openjdk</vendor>
-            <id>JavaSE-11</id>
-        </provides>
-        <configuration>
-            <jdkHome>${env.JAVA11_HOME}</jdkHome>
-        </configuration>
-    </toolchain>
-    <toolchain>
-        <type>jdk</type>
-        <provides>
             <version>17</version>
             <vendor>openjdk</vendor>
             <id>JavaSE-17</id>


### PR DESCRIPTION
Remove java8 and java11. They are not needed anymore since we build now with Java 17 only.

Introduce two composite actions:
- setup
- verify

* Refs #292 
* Refs #294 
