### PR TITLE
Use o.e.jdt.launching.macosx for configuring the installed JDKs in tests

### DIFF
--- a/com.basistech.m2e.code.quality.shared.test/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.shared.test/META-INF/MANIFEST.MF
@@ -10,8 +10,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,
  org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",
  org.junit,
- org.eclipse.m2e.tests.common;visibility:=reexport,
- org.eclipse.jdt.launching
+ org.eclipse.m2e.tests.common;visibility:=reexport
 Export-Package: com.basistech.m2e.code.quality.shared.test
 Import-Package: org.slf4j
 Automatic-Module-Name: com.basistech.m2e.code.quality.shared.test

--- a/com.basistech.m2e.code.quality.shared.test/src/main/java/com/basistech/m2e/code/quality/shared/test/AbstractMavenProjectConfiguratorTestCase.java
+++ b/com.basistech.m2e.code.quality.shared.test/src/main/java/com/basistech/m2e/code/quality/shared/test/AbstractMavenProjectConfiguratorTestCase.java
@@ -10,7 +10,6 @@ package com.basistech.m2e.code.quality.shared.test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.core.resources.ICommand;
@@ -20,11 +19,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.jdt.launching.IVMInstall;
-import org.eclipse.jdt.launching.IVMInstallType;
-import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
@@ -34,63 +29,6 @@ import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
 
 @SuppressWarnings("restriction")
 public abstract class AbstractMavenProjectConfiguratorTestCase extends AbstractMavenProjectTestCase {
-
-	@Override
-	public void setUp() throws Exception {
-		addDefaultJavaVMIfNeeded();
-		super.setUp();
-	}
-
-	/**
-	 * Setup a default JVM if none exists yet. This is especially required for mac
-	 * osx on github actions, as there is no default JVM detected automatically.
-	 * This is not done via the following extension, in order to check for the
-	 * existence of JAVA_HOME:
-	 *
-	 * <pre>
-	 *    &lt;extension
-	 *         point="org.eclipse.jdt.launching.vmInstalls">
-	 *      &lt;vmInstall
-	 *            home="${env_var:JAVA_HOME}"
-	 *            id="com.basistech.m2e.code.quality.shared.defaultJvm"
-	 *            name="defaultJvm"
-	 *            vmInstallType="org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType">
-	 *      &lt;/vmInstall>
-	 *   &lt;/extension>
-	 * </pre>
-	 */
-	private void addDefaultJavaVMIfNeeded() {
-		if (JavaRuntime.getDefaultVMInstall() != null
-				&& JavaRuntime.getDefaultVMInstall().getInstallLocation().exists()) {
-			return;
-		}
-
-		String javaHomeEnv = System.getenv("JAVA8_HOME");
-		if (javaHomeEnv == null) {
-			javaHomeEnv = System.getenv("JAVA_HOME");
-		}
-		if (javaHomeEnv == null) {
-			System.out.println("WARN: Neither JAVA8_HOME nor JAVA_HOME found!");
-			return;
-		}
-		File javaHome = new File(javaHomeEnv);
-		if (javaHome.exists()) {
-			try {
-				javaHome = javaHome.getCanonicalFile();
-				IVMInstallType vmInstallType = JavaRuntime
-						.getVMInstallType("org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType");
-				IVMInstall vm = vmInstallType.createVMInstall("com.basistech.m2e.code.quality.shared.defaultJvm");
-				vm.setInstallLocation(javaHome);
-				vm.setName("defaultJvm");
-				NullProgressMonitor monitor = new NullProgressMonitor();
-				JavaRuntime.setDefaultVMInstall(vm, monitor);
-			} catch (IOException | CoreException e) {
-				System.out.println("ERROR: Error setting up default JVM " + javaHome + ": " + e);
-			}
-		} else {
-			System.out.println("ERROR: Path " + javaHome + " does not exist");
-		}
-	}
 
 	protected boolean hasBuilder(final IProject project, final String id) throws Exception {
 		for (ICommand cmd : project.getDescription().getBuildSpec()) {

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,20 @@
                             </environments>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <groupId>org.eclipse.tycho</groupId>
+                        <artifactId>tycho-surefire-plugin</artifactId>
+                        <configuration>
+                            <dependencies combine.children="append">
+                                <!-- make sure to detect a default JVM -->
+                                <dependency>
+                                    <type>eclipse-plugin</type>
+                                    <artifactId>org.eclipse.jdt.launching.macosx</artifactId>
+                                    <version>0.0.0</version>
+                                </dependency>
+                            </dependencies>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
This removes the manual setup of the default JVM that was required for macos builds.

I've taken the inspiration from https://github.com/eclipse-m2e/m2e-core/blob/0aa663f75337f846f35a610bfb893f9c7c07605f/pom.xml#L410-L428