### PR TITLE
Remove usage of m2e-code-quality-bot and use github-actions[bot] instead

### DIFF
--- a/doc/github-actions.md
+++ b/doc/github-actions.md
@@ -15,8 +15,8 @@ That's the default token that is issued by github actions. It allows to push to 
 same repo as the action has been started. This token is used to generate a changelog
 and create a release.
 
-During the release, also some commits are done. These use the
-identity of [m2e-code-quality-bot](https://github.com/m2e-code-quality-bot).
+During the release, also some commits are done. These use the identity of
+[github-actions[bot]](https://api.github.com/users/github-actions[bot]).
 
 ### KEYSTORE_PASSWORD
 
@@ -33,7 +33,7 @@ with write access.
 This secret is written to `~/.ssh/m2e-code-quality-p2-site_deploy_key` in the script
 `tools/publish-update-site.sh`.
 
-For the commit, the identity of [m2e-code-quality-bot](https://github.com/m2e-code-quality-bot) is used.
+For the commit, the identity of [github-actions[bot]](https://api.github.com/users/github-actions[bot]) is used.
 
 ## What is being done
 

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -23,9 +23,4 @@ fi
 
 additional_options=("$@")
 
-# make org.jboss.tools.tycho-plugins:repository-utils happy:
-# for pull requests it sees a ref "refs/remotes/pull/<PR-Number>/merge"
-# but no remote named "pull" exists...
-git remote add pull https://github.com/m2e-code-quality/m2e-code-quality
-
 ./mvnw clean verify -e -B -V -ntp "${signing_options[@]}" "${additional_options[@]}"

--- a/tools/prepare_release.sh
+++ b/tools/prepare_release.sh
@@ -16,8 +16,9 @@ RELEASE_BRANCH=master
 echo "Preparing release ${RELEASE_TAG} on branch ${RELEASE_BRANCH}"
 
 # configure git
-git config --local user.name "m2e-code-quality-bot"
-git config --local user.email "m2e-code-quality-bot@users.noreply.github.com"
+# see https://github.com/orgs/community/discussions/26560 and https://api.github.com/users/github-actions[bot]
+git config --local user.name "github-actions[bot]"
+git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
 # verify same commit as branch
 HEAD=$(git rev-parse --verify HEAD)

--- a/tools/publish-update-site.sh
+++ b/tools/publish-update-site.sh
@@ -93,8 +93,10 @@ rm -rf "${CURRENT_SITE_FOLDER}"
 mkdir "${CURRENT_SITE_FOLDER}"
 pushd "${CURRENT_SITE_FOLDER}"
 git init -q --initial-branch="${SITE_GITHUB_BRANCH}"
-git config --local user.name "m2e-code-quality-bot"
-git config --local user.email "m2e-code-quality-bot@users.noreply.github.com"
+# configure git
+# see https://github.com/orgs/community/discussions/26560 and https://api.github.com/users/github-actions[bot]
+git config --local user.name "github-actions[bot]"
+git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
 git remote add origin "${SITE_GITHUB_REPO_URL}"
 git pull --rebase origin "${SITE_GITHUB_BRANCH}"
 popd


### PR DESCRIPTION
Uses github-actions[bot] as commit identity

* Refs #282
* See https://github.com/orgs/community/discussions/26560 and https://api.github.com/users/github-actions[bot]
