### PR TITLE
Replace GabrielBB/xvfb-action with direct xvfb-run call

### DIFF
--- a/.github/actions/verify/action.yml
+++ b/.github/actions/verify/action.yml
@@ -21,8 +21,10 @@ runs:
   using: 'composite'
   steps:
     - name: Build with Maven
-      uses: GabrielBB/xvfb-action@v1
-      with:
-        run: bash tools/build.sh -Dtarget.platform=${{ inputs.targetPlatform }} -Dmaven.test.skip=${{ inputs.skipTests }}
+      run: |
+        XVFB=""
+        [ "${{ runner.os }}" = "Linux" ] && XVFB="xvfb-run --auto-servernum"
+        $XVFB bash tools/build.sh -Dtarget.platform=${{ inputs.targetPlatform }} -Dmaven.test.skip=${{ inputs.skipTests }}
+      shell: bash
       env:
         KEYSTORE_PASSWORD: ${{ inputs.keystorePassword }}


### PR DESCRIPTION
This gets rid of the deprecation warnings:

```
fail-fast verify (ubuntu-latest, 2022-09)
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: GabrielBB/xvfb-action@v1
```