### PR TITLE
Add support for excludeBugsFile option for SpotBugs

### DIFF
--- a/com.basistech.m2e.code.quality.spotbugs.test/projects/exclude-bugs-file/README.markdown
+++ b/com.basistech.m2e.code.quality.spotbugs.test/projects/exclude-bugs-file/README.markdown
@@ -1,0 +1,5 @@
+# exclude-bugs-file
+
+A test project that is configured to run the spotbugs:spotbugs goal on build
+with a configured `exclude-bugs-file` property.
+It should trigger only one SpotBugs marker - the other should be excluded (see file `baseline.xml`).

--- a/com.basistech.m2e.code.quality.spotbugs.test/projects/exclude-bugs-file/baseline.xml
+++ b/com.basistech.m2e.code.quality.spotbugs.test/projects/exclude-bugs-file/baseline.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<BugCollection sequence='0' release=''
+  analysisTimestamp='1683129410629' version='4.7.3'
+  timestamp='1683129395900'>
+  <BugInstance instanceOccurrenceNum='0'
+    instanceHash='901dec069e7895775d5e3e88f893c9d7' cweid='440' rank='7'
+    abbrev='RV' category='CORRECTNESS' priority='1'
+    type='RV_ABSOLUTE_VALUE_OF_HASHCODE' instanceOccurrenceMax='0'>
+    <ShortMessage>Bad attempt to compute absolute value of signed 32-bit
+      hashcode</ShortMessage>
+    <LongMessage>Bad attempt to compute absolute value of signed 32-bit
+      hashcode in cat.App.main(String[])</LongMessage>
+    <Class classname='cat.App' primary='true'>
+      <SourceLine classname='cat.App' start='7' end='15'
+        sourcepath='cat/App.java' sourcefile='App.java'>
+        <Message>At App.java:[lines 7-15]</Message>
+      </SourceLine>
+      <Message>In class cat.App</Message>
+    </Class>
+    <Method isStatic='true' classname='cat.App'
+      signature='([Ljava/lang/String;)V' name='main' primary='true'>
+      <SourceLine endBytecode='154' classname='cat.App'
+        start='9' end='15' sourcepath='cat/App.java'
+        sourcefile='App.java' startBytecode='0'></SourceLine>
+      <Message>In method cat.App.main(String[])</Message>
+    </Method>
+    <SourceLine endBytecode='16' classname='cat.App'
+      start='11' end='11' sourcepath='cat/App.java'
+      sourcefile='App.java' startBytecode='16' primary='true'>
+      <Message>At App.java:[line 11]</Message>
+    </SourceLine>
+  </BugInstance>
+</BugCollection>

--- a/com.basistech.m2e.code.quality.spotbugs.test/projects/exclude-bugs-file/pom.xml
+++ b/com.basistech.m2e.code.quality.spotbugs.test/projects/exclude-bugs-file/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.basistech</groupId>
+	<artifactId>spotbugs-exclude-bugs-file</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.release>17</maven.compiler.release>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.11.0</version>
+			</plugin>
+			<plugin>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>4.7.3.4</version>
+				<configuration>
+					<excludeBugsFile>baseline.xml</excludeBugsFile>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>spotbugs</goal>
+						</goals>
+						<phase>verify</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/com.basistech.m2e.code.quality.spotbugs.test/projects/exclude-bugs-file/src/main/java/cat/App.java
+++ b/com.basistech.m2e.code.quality.spotbugs.test/projects/exclude-bugs-file/src/main/java/cat/App.java
@@ -1,0 +1,16 @@
+package cat;
+
+/**
+ * Hello world!
+ *
+ */
+public class App {
+	public static void main(String[] args) {
+		Object[] bucket = new Object[12345];
+		String y = args[0];
+		Object x = bucket[Math.abs(y.hashCode()) % bucket.length]; // RV_ABSOLUTE_VALUE_OF_HASHCODE - filtered
+		System.out.println("Hello World!" + x);
+		x = bucket[y.hashCode() % bucket.length]; // RV_REM_OF_HASHCODE
+		System.out.println("Hello World!" + x);
+	}
+}

--- a/com.basistech.m2e.code.quality.spotbugs.test/src/main/java/com/basistech/m2e/code/quality/spotbugs/tests/EclipseSpotbugsProjectConfigurationTest.java
+++ b/com.basistech.m2e.code.quality.spotbugs.test/src/main/java/com/basistech/m2e/code/quality/spotbugs/tests/EclipseSpotbugsProjectConfigurationTest.java
@@ -8,12 +8,14 @@
  *******************************************************************************/
 package com.basistech.m2e.code.quality.spotbugs.tests;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.junit.Test;
@@ -43,6 +45,16 @@ public class EclipseSpotbugsProjectConfigurationTest extends AbstractMavenProjec
 	public void testSpotbugsSpotbugs() throws Exception {
 		importProjectRunBuildAndFindMarkers("projects/spotbugs-spotbugs/pom.xml", MARKER_ID, 2,
 				new TriggerSpotbugsExplicitly());
+	}
+
+	@Test
+	public void testSpotbugsExcludeBugsFile() throws Exception {
+		final IProject project = importProject("projects/exclude-bugs-file/pom.xml");
+		runBuild(project, new TriggerSpotbugsExplicitly());
+		final IMarker[] markers = findMarkers(project, MARKER_ID);
+		assertEquals("Expected exactly one marker, but got " + markers.length, 1, markers.length);
+		int lineNumber = markers[0].getAttribute(IMarker.LINE_NUMBER, -1);
+		assertEquals("Expected the marker at line 13", 13, lineNumber);
 	}
 
 	@Test

--- a/com.basistech.m2e.code.quality.spotbugs/src/main/java/com/basistech/m2e/code/quality/spotbugs/EclipseSpotbugsProjectConfigurator.java
+++ b/com.basistech.m2e.code.quality.spotbugs/src/main/java/com/basistech/m2e/code/quality/spotbugs/EclipseSpotbugsProjectConfigurator.java
@@ -99,6 +99,7 @@ public class EclipseSpotbugsProjectConfigurator extends AbstractMavenPluginProje
 		final UserPreferences prefs = UserPreferences.createDefaultUserPreferences();
 		pluginCfgTranslator.setIncludeFilterFiles(prefs);
 		pluginCfgTranslator.setExcludeFilterFiles(prefs);
+		pluginCfgTranslator.setExcludeBugsFiles(prefs);
 		// pluginCfgTranslator.setBugCatagories(prefs);
 		pluginCfgTranslator.setEffort(prefs);
 		pluginCfgTranslator.setMinRank(prefs);

--- a/com.basistech.m2e.code.quality.spotbugs/src/main/java/com/basistech/m2e/code/quality/spotbugs/MavenPluginConfigurationTranslator.java
+++ b/com.basistech.m2e.code.quality.spotbugs/src/main/java/com/basistech/m2e/code/quality/spotbugs/MavenPluginConfigurationTranslator.java
@@ -19,7 +19,9 @@ package com.basistech.m2e.code.quality.spotbugs;
 import static com.basistech.m2e.code.quality.spotbugs.SpotbugsEclipseConstants.BUG_CATEGORIES;
 import static com.basistech.m2e.code.quality.spotbugs.SpotbugsEclipseConstants.DEBUG;
 import static com.basistech.m2e.code.quality.spotbugs.SpotbugsEclipseConstants.EFFORT;
+import static com.basistech.m2e.code.quality.spotbugs.SpotbugsEclipseConstants.EXCLUDE_BUGS_FILE;
 import static com.basistech.m2e.code.quality.spotbugs.SpotbugsEclipseConstants.EXCLUDE_FILTER_FILE;
+import static com.basistech.m2e.code.quality.spotbugs.SpotbugsEclipseConstants.FB_EXCLUDE_BUGS_FILE;
 import static com.basistech.m2e.code.quality.spotbugs.SpotbugsEclipseConstants.FB_EXCLUDE_FILTER_FILE;
 import static com.basistech.m2e.code.quality.spotbugs.SpotbugsEclipseConstants.FB_INCLUDE_FILTER_FILE;
 import static com.basistech.m2e.code.quality.spotbugs.SpotbugsEclipseConstants.INCLUDE_FILTER_FILE;
@@ -114,6 +116,26 @@ public class MavenPluginConfigurationTranslator extends AbstractMavenPluginConfi
 		}
 		newExcludeFilteredFiles.putAll(curExcludeFilteredFiles);
 		prefs.setExcludeFilterFiles(newExcludeFilteredFiles);
+	}
+
+	public void setExcludeBugsFiles(final UserPreferences prefs) throws CoreException {
+		LOG.debug("entering setExcludeBugsFiles");
+		final String excludeBugsFile = getParameterValue(EXCLUDE_BUGS_FILE, String.class);
+		// don't do anything if null
+		if (excludeBugsFile == null) {
+			LOG.debug("excludeBugsFile is null");
+			return;
+		}
+		List<String> filterFiles = this.copyUrlResourcesToProject(excludeBugsFile, FB_EXCLUDE_BUGS_FILE);
+		final Map<String, Boolean> curExcludeBugsFiles = prefs.getExcludeBugsFiles();
+		final Map<String, Boolean> newExcludeBugsFiles = new HashMap<>();
+		for (String filterFile : filterFiles) {
+			if (!curExcludeBugsFiles.containsKey(filterFile)) {
+				newExcludeBugsFiles.put(filterFile, Boolean.TRUE);
+			}
+		}
+		newExcludeBugsFiles.putAll(curExcludeBugsFiles);
+		prefs.setExcludeBugsFiles(newExcludeBugsFiles);
 	}
 
 	/**

--- a/com.basistech.m2e.code.quality.spotbugs/src/main/java/com/basistech/m2e/code/quality/spotbugs/SpotbugsEclipseConstants.java
+++ b/com.basistech.m2e.code.quality.spotbugs/src/main/java/com/basistech/m2e/code/quality/spotbugs/SpotbugsEclipseConstants.java
@@ -27,6 +27,7 @@ public final class SpotbugsEclipseConstants {
 			"edu.umd.cs.findbugs.plugin.eclipse.findbugsNature";
 	public static final String FB_EXCLUDE_FILTER_FILE = ".fbExcludeFilterFile";
 	public static final String FB_INCLUDE_FILTER_FILE = ".fbIncludeFilterFile";
+	public static final String FB_EXCLUDE_BUGS_FILE = ".fbExcludeBugsFile";
 	public static final String VISITORS = "visitors";
 	public static final String THRESHOLD = "threshold";
 	public static final String OMIT_VISITORS = "omitVisitors";
@@ -36,6 +37,7 @@ public final class SpotbugsEclipseConstants {
 	public static final String BUG_CATEGORIES = "bugCategories";
 	public static final String EXCLUDE_FILTER_FILE = "excludeFilterFile";
 	public static final String INCLUDE_FILTER_FILE = "includeFilterFile";
+	public static final String EXCLUDE_BUGS_FILE = "excludeBugsFile";
 	public static final String MAX_RANK = "maxRank";
 	public static final String SKIP = "skip";
 


### PR DESCRIPTION
It would be good to be able to use the [`excludeBugsFile` option](https://spotbugs.github.io/spotbugs-maven-plugin/spotbugs-mojo.html#excludeBugsFile) with m2e.

This patch adds support for it (mostly adapted from code handling `excludeFilterFile`).