### PR TITLE
[spotbugs] Add in 'verify' as a valid goal

### DIFF
--- a/com.basistech.m2e.code.quality.spotbugs/src/main/java/com/basistech/m2e/code/quality/spotbugs/EclipseSpotbugsProjectConfigurator.java
+++ b/com.basistech.m2e.code.quality.spotbugs/src/main/java/com/basistech/m2e/code/quality/spotbugs/EclipseSpotbugsProjectConfigurator.java
@@ -58,7 +58,7 @@ public class EclipseSpotbugsProjectConfigurator extends AbstractMavenPluginProje
 
 	@Override
 	protected String[] getMavenPluginGoals() {
-		return new String[] { "spotbugs", "check" };
+		return new String[] { "spotbugs", "check", "verify" };
 	}
 
 	@Override


### PR DESCRIPTION
'verify' goal was added to maven project a long time ago.  I don't see any tests at all for spotbugs nor pmd, so I just aimed for getting the newer goal to be available here.

See https://github.com/search?q=repo%3Aspotbugs%2Fspotbugs-maven-plugin+%40Mojo&type=code

I didn't bother with 'gui' although that could be ran from Eclipse but typically would not.

Spotbugs verify mojo: https://spotbugs.github.io/spotbugs-maven-plugin/verify-mojo.html
Description of this goal, see https://github.com/spotbugs/spotbugs-maven-plugin/blob/master/src/main/groovy/org/codehaus/mojo/spotbugs/VerifyMojo.groovy
