### PR TITLE
Support eclipse 2024-03

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   # verify build on one node before multiple builds on different os are started
   fail-fast-build:
-    name: fail-fast verify (ubuntu-latest, 2023-12)
+    name: fail-fast verify (ubuntu-latest, 2024-03)
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -33,7 +33,7 @@ jobs:
 
       - uses: ./.github/actions/verify
         with:
-          targetPlatform: 2023-12
+          targetPlatform: 2024-03
 
   verify:
     needs: fail-fast-build
@@ -43,13 +43,15 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        targetPlatform: [ 2023-12 ]
+        targetPlatform: [ 2024-03 ]
         exclude:
           # exclude the fail-fast-build, which already ran
           - os: ubuntu-latest
-            targetPlatform: 2023-12
+            targetPlatform: 2024-03
         # run some other target platforms only on linux
         include:
+          #- os: ubuntu-latest
+          #  targetPlatform: 2023-12
           #- os: ubuntu-latest
           #  targetPlatform: 2023-09
           #- os: ubuntu-latest
@@ -89,7 +91,7 @@ jobs:
 
       - uses: ./.github/actions/verify
         with:
-          targetPlatform: 2023-12
+          targetPlatform: 2024-03
           keystorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
           skipTests: 'true'
 
@@ -122,7 +124,7 @@ jobs:
 
       - uses: ./.github/actions/verify
         with:
-          targetPlatform: 2023-12
+          targetPlatform: 2024-03
           keystorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
           skipTests: 'true'
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <!-- default target platform -->
-        <target.platform>2023-12</target.platform>
+        <target.platform>2024-03</target.platform>
         <target.ee>JavaSE-17</target.ee>
 
         <tycho-version>4.0.4</tycho-version>

--- a/target-platforms/2024-03.target
+++ b/target-platforms/2024-03.target
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="Eclipse 4.31.x (2024-03)">
+    <locations>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="org.eclipse.platform.ide" version="0.0.0"/>
+            <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
+            <unit id="org.eclipse.m2e.sdk.feature.feature.group" version="0.0.0"/>
+            <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
+            <unit id="org.apache.commons.lang" version="0.0.0"/>
+            <repository location="https://download.eclipse.org/releases/2024-03/"/>
+         </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="net.sf.eclipsecs.feature.group" version="0.0.0"/>
+            <repository location="https://checkstyle.org/eclipse-cs-update-site/"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="net.sourceforge.pmd.eclipse.feature.group" version="0.0.0"/>
+            <repository location="https://pmd.github.io/pmd-eclipse-plugin-p2-site/"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="edu.umd.cs.findbugs.plugin.eclipse.feature.group" version="0.0.0"/>
+            <repository location="https://findbugs.cs.umd.edu/eclipse/"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="com.github.spotbugs.plugin.eclipse.feature.group" version="0.0.0"/>
+            <repository location="https://spotbugs.github.io/eclipse/"/>
+        </location>
+    </locations>
+    <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+</target>


### PR DESCRIPTION
- 2024-03 is built and tested by default on all operating systems
- 2022-09 is the oldest one, that is built and tested on linux only
- all other versions might or might not work

