### PR TITLE
[ci] Support macosx/cocoa/aarch64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,11 @@
                                     <ws>cocoa</ws>
                                     <arch>x86_64</arch>
                                 </environment>
+                                <environment>
+                                    <os>macosx</os>
+                                    <ws>cocoa</ws>
+                                    <arch>aarch64</arch>
+                                </environment>
                             </environments>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
Currently the GitHub Actions builds are failing, because the macos-latest now runs on arm64 hardware.
-> https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md