### PR TITLE
Move old releases into separate update site

### DIFF
--- a/tools/old_releases.list
+++ b/tools/old_releases.list
@@ -1,5 +1,0 @@
-http://m2e-code-quality.github.io/m2e-code-quality/site/1.0.0.201501120825/
-http://m2e-code-quality.github.io/m2e-code-quality/site/1.0.0.201503101518/
-http://m2e-code-quality.github.io/m2e-code-quality/site/1.0.0.201602071612/
-http://m2e-code-quality.github.io/m2e-code-quality/site/1.0.0.201608091842/
-http://m2e-code-quality.github.io/m2e-code-quality/site/1.0.0.201705301746/


### PR DESCRIPTION
I've already moved the old releases on the p2-site - see https://m2e-code-quality.github.io/m2e-code-quality-p2-site/ and https://m2e-code-quality.github.io/m2e-code-quality-p2-site/old/

This now makes sure, we don't add the old releases back into the main composite repo.

If some update sites change again and become unavailable, we might need to move more releases into the old repository. But for now, only the 1.x versions seem to be enough.

- Fixes #344
