### PR TITLE
Fix propertyExpansion for checkstyle

### DIFF
--- a/com.basistech.m2e.code.quality.checkstyle.test/projects/checkstyle-propertyExpansion/README.markdown
+++ b/com.basistech.m2e.code.quality.checkstyle.test/projects/checkstyle-propertyExpansion/README.markdown
@@ -1,0 +1,5 @@
+# checkstyle-propertyExpansion
+
+A test project that is configured to run the checkstyle:check goal on build.
+It should properly use the properties and should not trigger any markers.
+Example is from <https://maven.apache.org/plugins/maven-checkstyle-plugin/examples/custom-property-expansion.html>.

--- a/com.basistech.m2e.code.quality.checkstyle.test/projects/checkstyle-propertyExpansion/checkstyle.xml
+++ b/com.basistech.m2e.code.quality.checkstyle.test/projects/checkstyle-propertyExpansion/checkstyle.xml
@@ -1,0 +1,12 @@
+<!DOCTYPE module PUBLIC
+  "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
+  "https://checkstyle.org/dtds/configuration_1_2.dtd">
+
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="PackageName">
+      <property name="format"
+         value="^com\.example\.${projectname}(\.[a-z][a-zA-Z0-9]+)*$"/>
+    </module>
+  </module>
+</module>

--- a/com.basistech.m2e.code.quality.checkstyle.test/projects/checkstyle-propertyExpansion/pom.xml
+++ b/com.basistech.m2e.code.quality.checkstyle.test/projects/checkstyle-propertyExpansion/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.basistech</groupId>
+	<artifactId>checkstyle-propertyExpansion</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>3.1.0</version>
+				<configuration>
+					<configLocation>checkstyle.xml</configLocation>
+					<propertyExpansion>
+						firstProperty=C:\foo\bar.txt
+						projectname=whizbang
+						anotherProperty=bazinga
+					</propertyExpansion>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>com.puppycrawl.tools</groupId>
+						<artifactId>checkstyle</artifactId>
+						<version>8.29</version>
+					</dependency>
+				</dependencies>
+				<executions>
+					<execution>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+	<profiles>
+		<profile>
+			<id>skip</id>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-checkstyle-plugin</artifactId>
+							<version>3.0.0</version>
+							<configuration>
+								<skip>true</skip>
+							</configuration>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
+	</profiles>
+</project>

--- a/com.basistech.m2e.code.quality.checkstyle.test/projects/checkstyle-propertyExpansion/src/main/java/com/example/whizbang/App.java
+++ b/com.basistech.m2e.code.quality.checkstyle.test/projects/checkstyle-propertyExpansion/src/main/java/com/example/whizbang/App.java
@@ -1,0 +1,13 @@
+package com.example.whizbang;
+
+/**
+ * Hello world!
+ *
+ */
+public class App 
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+    }
+}

--- a/com.basistech.m2e.code.quality.checkstyle.test/src/main/java/com/basistech/m2e/code/quality/checkstyle/test/EclipseCheckstyleProjectConfigurationTest.java
+++ b/com.basistech.m2e.code.quality.checkstyle.test/src/main/java/com/basistech/m2e/code/quality/checkstyle/test/EclipseCheckstyleProjectConfigurationTest.java
@@ -168,6 +168,15 @@ public class EclipseCheckstyleProjectConfigurationTest extends AbstractMavenProj
 		assertMarkers(module1, MARKER_ID, 1);
 	}
 
+	@Test
+	public void testCheckstylePropertyExpansion() throws Exception {
+		final IProject p = importProject("projects/checkstyle-propertyExpansion/pom.xml");
+		assertTrue(p.exists());
+
+		runBuild(p);
+		assertNoMarkers(p, MARKER_ID);
+	}
+
 	private final class TriggerCheckstyleExplicitly implements ProjectCallable {
 
 		@Override

--- a/com.basistech.m2e.code.quality.checkstyle/META-INF/MANIFEST.MF
+++ b/com.basistech.m2e.code.quality.checkstyle/META-INF/MANIFEST.MF
@@ -13,8 +13,7 @@ Require-Bundle: org.eclipse.core.runtime,
  com.basistech.m2e.code.quality.shared;bundle-version="2.2.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: Basis Technology Corp.
-Import-Package: org.apache.commons.lang,
- org.eclipse.jface.preference,
+Import-Package: org.eclipse.jface.preference,
  org.eclipse.swt.widgets,
  org.eclipse.ui,
  org.eclipse.ui.plugin,

--- a/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/MavenPluginConfigurationTranslator.java
+++ b/com.basistech.m2e.code.quality.checkstyle/src/main/java/com/basistech/m2e/code/quality/checkstyle/MavenPluginConfigurationTranslator.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
-import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
@@ -481,7 +480,7 @@ public class MavenPluginConfigurationTranslator extends AbstractMavenPluginConfi
 		if (propertyExpansion != null) {
 			try {
 				// beware of windows path separator
-				final String escapedPropertyExpansion = StringEscapeUtils.escapeJava(propertyExpansion);
+				final String escapedPropertyExpansion = propertyExpansion.replace("\\", "\\\\");
 				props.load(new StringReader(escapedPropertyExpansion));
 			} catch (final IOException e) {
 				throw new CheckstylePluginException(String.format("[%s]: Failed to checkstyle propertyExpansion [%s]",

--- a/target-platforms/2025-06.target
+++ b/target-platforms/2025-06.target
@@ -7,7 +7,6 @@
             <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.m2e.sdk.feature.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
-            <unit id="org.apache.commons.lang" version="0.0.0"/>
             <repository location="https://download.eclipse.org/releases/2025-06/"/>
          </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
This actually didn't work.
Now, we don't depend on commons-lang anymore which unlocks #397 .

Whether the escaping of the backslashes actually works or whether it just masks a bug in checkstyle, I don't know.