### PR TITLE
chore: update maven plugins in test projects

### DIFF
--- a/com.basistech.m2e.code.quality.checkstyle.test/projects/checkstyle-check/pom.xml
+++ b/com.basistech.m2e.code.quality.checkstyle.test/projects/checkstyle-check/pom.xml
@@ -17,12 +17,12 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.6.0</version>
 				<dependencies>
 					<dependency>
 						<groupId>com.puppycrawl.tools</groupId>
 						<artifactId>checkstyle</artifactId>
-						<version>8.29</version>
+						<version>12.3.0</version>
 					</dependency>
 				</dependencies>
 				<executions>
@@ -45,7 +45,7 @@
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-checkstyle-plugin</artifactId>
-							<version>3.0.0</version>
+							<version>3.6.0</version>
 							<configuration>
 								<skip>true</skip>
 							</configuration>

--- a/com.basistech.m2e.code.quality.checkstyle.test/projects/checkstyle-multi-check/pom.xml
+++ b/com.basistech.m2e.code.quality.checkstyle.test/projects/checkstyle-multi-check/pom.xml
@@ -17,12 +17,12 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.6.0</version>
 				<dependencies>
 					<dependency>
 						<groupId>com.puppycrawl.tools</groupId>
 						<artifactId>checkstyle</artifactId>
-						<version>8.29</version>
+						<version>12.3.0</version>
 					</dependency>
 				</dependencies>
 				<executions>
@@ -52,7 +52,7 @@
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-checkstyle-plugin</artifactId>
-							<version>3.1.0</version>
+							<version>3.6.0</version>
 							<configuration>
 								<skip>true</skip>
 							</configuration>
@@ -69,7 +69,7 @@
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-checkstyle-plugin</artifactId>
-							<version>3.1.0</version>
+							<version>3.6.0</version>
 							<executions>
 								<execution>
 									<id>second</id>

--- a/com.basistech.m2e.code.quality.checkstyle.test/projects/checkstyle-multi-module/pom.xml
+++ b/com.basistech.m2e.code.quality.checkstyle.test/projects/checkstyle-multi-module/pom.xml
@@ -17,7 +17,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>3.2.0</version>
+				<version>3.6.0</version>
 				<configuration>
 					<configLocation>checks/checkstyle_config.xml</configLocation>
 				</configuration>

--- a/com.basistech.m2e.code.quality.checkstyle.test/projects/checkstyle-propertyExpansion/pom.xml
+++ b/com.basistech.m2e.code.quality.checkstyle.test/projects/checkstyle-propertyExpansion/pom.xml
@@ -17,7 +17,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.6.0</version>
 				<configuration>
 					<configLocation>checkstyle.xml</configLocation>
 					<propertyExpansion>
@@ -30,7 +30,7 @@
 					<dependency>
 						<groupId>com.puppycrawl.tools</groupId>
 						<artifactId>checkstyle</artifactId>
-						<version>8.29</version>
+						<version>12.3.0</version>
 					</dependency>
 				</dependencies>
 				<executions>
@@ -53,7 +53,7 @@
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-checkstyle-plugin</artifactId>
-							<version>3.0.0</version>
+							<version>3.6.0</version>
 							<configuration>
 								<skip>true</skip>
 							</configuration>

--- a/com.basistech.m2e.code.quality.findbugs.test/projects/findbugs-check/pom.xml
+++ b/com.basistech.m2e.code.quality.findbugs.test/projects/findbugs-check/pom.xml
@@ -17,7 +17,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>2.5.4</version>
+				<version>3.0.5</version>
 				<executions>
 					<execution>
 						<goals>
@@ -38,7 +38,7 @@
 						<plugin>
 							<groupId>org.codehaus.mojo</groupId>
 							<artifactId>findbugs-maven-plugin</artifactId>
-							<version>2.5.4</version>
+							<version>3.0.5</version>
 							<configuration>
 								<skip>true</skip>
 							</configuration>

--- a/com.basistech.m2e.code.quality.findbugs.test/projects/findbugs-findbugs/pom.xml
+++ b/com.basistech.m2e.code.quality.findbugs.test/projects/findbugs-findbugs/pom.xml
@@ -17,7 +17,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>2.5.4</version>
+				<version>3.0.5</version>
 				<executions>
 					<execution>
 						<goals>

--- a/com.basistech.m2e.code.quality.pmd.test/projects/pmd-check/pom.xml
+++ b/com.basistech.m2e.code.quality.pmd.test/projects/pmd-check/pom.xml
@@ -17,7 +17,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
-				<version>3.20.0</version>
+				<version>3.28.0</version>
 				<executions>
 					<execution>
 						<goals>
@@ -38,7 +38,7 @@
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-pmd-plugin</artifactId>
-							<version>3.20.0</version>
+							<version>3.28.0</version>
 							<configuration>
 								<skip>true</skip>
 							</configuration>

--- a/com.basistech.m2e.code.quality.pmd.test/projects/pmd-custom-ruleset-with-property/pom.xml
+++ b/com.basistech.m2e.code.quality.pmd.test/projects/pmd-custom-ruleset-with-property/pom.xml
@@ -17,7 +17,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
-				<version>3.25.0</version>
+				<version>3.28.0</version>
 				<configuration>
 					<rulesets>
 						<ruleset>custom-ruleset.xml</ruleset>

--- a/com.basistech.m2e.code.quality.pmd.test/projects/pmd-custom-ruleset/pom.xml
+++ b/com.basistech.m2e.code.quality.pmd.test/projects/pmd-custom-ruleset/pom.xml
@@ -17,7 +17,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
-				<version>3.20.0</version>
+				<version>3.28.0</version>
 				<configuration>
 					<rulesets>
 						<ruleset>custom-ruleset.xml</ruleset>

--- a/com.basistech.m2e.code.quality.spotbugs.test/projects/exclude-bugs-file/pom.xml
+++ b/com.basistech.m2e.code.quality.spotbugs.test/projects/exclude-bugs-file/pom.xml
@@ -18,12 +18,12 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.11.0</version>
+				<version>3.14.1</version>
 			</plugin>
 			<plugin>
 				<groupId>com.github.spotbugs</groupId>
 				<artifactId>spotbugs-maven-plugin</artifactId>
-				<version>4.7.3.4</version>
+				<version>4.9.8.2</version>
 				<configuration>
 					<excludeBugsFile>baseline.xml</excludeBugsFile>
 				</configuration>

--- a/com.basistech.m2e.code.quality.spotbugs.test/projects/spotbugs-check/pom.xml
+++ b/com.basistech.m2e.code.quality.spotbugs.test/projects/spotbugs-check/pom.xml
@@ -17,7 +17,7 @@
 			<plugin>
 				<groupId>com.github.spotbugs</groupId>
 				<artifactId>spotbugs-maven-plugin</artifactId>
-				<version>3.1.6</version>
+				<version>4.9.8.2</version>
 				<executions>
 					<execution>
 						<goals>
@@ -38,7 +38,7 @@
 						<plugin>
 							<groupId>com.github.spotbugs</groupId>
 							<artifactId>spotbugs-maven-plugin</artifactId>
-							<version>3.1.6</version>
+							<version>4.9.8.2</version>
 							<configuration>
 								<skip>true</skip>
 							</configuration>

--- a/com.basistech.m2e.code.quality.spotbugs.test/projects/spotbugs-spotbugs/pom.xml
+++ b/com.basistech.m2e.code.quality.spotbugs.test/projects/spotbugs-spotbugs/pom.xml
@@ -17,7 +17,7 @@
 			<plugin>
 				<groupId>com.github.spotbugs</groupId>
 				<artifactId>spotbugs-maven-plugin</artifactId>
-				<version>3.1.6</version>
+				<version>4.9.8.2</version>
 				<executions>
 					<execution>
 						<goals>

--- a/com.basistech.m2e.code.quality.spotbugs.test/projects/spotbugs-verify/pom.xml
+++ b/com.basistech.m2e.code.quality.spotbugs.test/projects/spotbugs-verify/pom.xml
@@ -18,7 +18,7 @@
 				<plugin>
 					<groupId>com.github.spotbugs</groupId>
 					<artifactId>spotbugs-maven-plugin</artifactId>
-					<version>4.8.4.0</version>
+					<version>4.9.8.2</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION

This gets rid of the following warnings during build

```
!MESSAGE Warning at /rulesets/java/maven-pmd-plugin-default.xml:75:5
 73|     <rule ref="category/java/errorprone.xml/UnnecessaryConversionTemporary" />
 74|     <rule ref="category/java/errorprone.xml/UnusedNullCheckInEquals" />
 75|     <rule ref="category/java/errorprone.xml/UselessOperationOnImmutable" />
         ^^^^^ Discontinue using Rule name category/java/errorprone.xml/UselessOperationOnImmutable as it is scheduled for removal from PMD. PMD 8.0.0 will remove support for this Rule.

 76| 
 77|     <rule ref="category/java/multithreading.xml/AvoidThreadGroup" />
```
