### PR TITLE
Bump github_changelog_generator from 1.16.4 to 1.18.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 # bleeding edge from git
-gem 'github_changelog_generator', :git => 'https://github.com/github-changelog-generator/github-changelog-generator.git', branch: 'master'
+#gem 'github_changelog_generator', :git => 'https://github.com/github-changelog-generator/github-changelog-generator.git', branch: 'master'
 
-#gem 'github_changelog_generator'
+gem 'github_changelog_generator', '~> 1.18'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,3 @@
-GIT
-  remote: https://github.com/github-changelog-generator/github-changelog-generator.git
-  revision: df6622dbdc907e7c3a4f851383a47c47715393b2
-  branch: master
-  specs:
-    github_changelog_generator (1.16.4)
-      activesupport
-      async (>= 1.25.0)
-      async-http-faraday
-      benchmark
-      faraday-http-cache
-      octokit (~> 4.6)
-      rainbow (>= 2.2.1)
-      rake (>= 10.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -75,6 +60,15 @@ GEM
     fiber-local (1.1.0)
       fiber-storage
     fiber-storage (1.0.1)
+    github_changelog_generator (1.18.0)
+      activesupport
+      async (>= 1.25.0)
+      async-http-faraday
+      benchmark
+      faraday-http-cache
+      octokit (~> 4.6)
+      rainbow (>= 2.2.1)
+      rake (>= 10.0)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-endpoint (0.17.2)
@@ -115,7 +109,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  github_changelog_generator!
+  github_changelog_generator (~> 1.18)
 
 BUNDLED WITH
   4.0.6


### PR DESCRIPTION
* https://github.com/github-changelog-generator/github-changelog-generator/releases/tag/v1.17.0
* https://github.com/github-changelog-generator/github-changelog-generator/releases/tag/v1.18.0

This replaces #411 