### PR TITLE
Pin checkstyle to 12.3.1 for 2022-09 target

### DIFF
--- a/target-platforms/2022-09.target
+++ b/target-platforms/2022-09.target
@@ -11,7 +11,7 @@
             <repository location="https://download.eclipse.org/releases/2022-09/"/>
          </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="net.sf.eclipsecs.feature.group" version="0.0.0"/>
+            <unit id="net.sf.eclipsecs.feature.group" version="12.3.1.202603160223"/>
             <repository location="https://checkstyle.org/eclipse-cs-update-site/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
This is the last version that is compatible with Java 17. Newer checkstyle versions require Java 21 and are covered by the newer target platform definitions.